### PR TITLE
Fix event handling and prevent duplicate key events

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use crate::{
     shapes::enums::LanguageEnum,
 };
 use crossterm::{
-    event::{self, Event, KeyCode},
+    event::{self, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -178,8 +178,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
             }
         })?;
 
-        if event::poll(std::time::Duration::from_millis(200))? {
-            if let Event::Key(key) = event::read()? {
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press {
                 if key.code == KeyCode::Char('q') {
                     return Ok(());
                 }


### PR DESCRIPTION
Problem- 
On Windows, crossterm reports both KeyEventKind::Press and KeyEventKind::Release events

Solution-
Filter key events to handle KeyEventKind::Press

Changes-
Removes 200ms polling timeout for responsiveness
Add key.kind == KeyEventKind::Press check to prevent duplicate events

References-
https://docs.rs/crossterm/latest/crossterm/event/struct.KeyEvent.html#structfield.kind
https://github.com/ratatui/ratatui/issues/120
https://github.com/ratatui/ratatui/issues/347

Testing-
Verify single action per keypress on Windows11
Confirmed functionality on Linux 6.16.3-arch1-1
