### PR TITLE
Allowing users to report an issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,9 @@ jobs:
           target: ${{ matrix.platforms.target }}
           args: "--verbose --locked --release ${{ matrix.platforms.features }}"
           strip: true
+        env:
+          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
       - name: setup variables
         id: variables
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,21 +157,6 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.1",
-]
 
 [[package]]
 name = "base64"
@@ -564,6 +540,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +907,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1192,21 +1215,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -1219,12 +1242,6 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1439,9 +1456,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1828,17 +1847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,7 +1889,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -2008,6 +2016,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,7 +2100,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2092,7 +2112,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -2189,15 +2209,6 @@ name = "numerals"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -2505,12 +2516,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "psm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66fcd288453b748497d8fb18bccc83a16b0518e3906d4b8df0a8d42d93dbb1c"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -2589,7 +2616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -2683,7 +2710,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2805,6 +2832,9 @@ checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2818,6 +2848,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2896,12 +2927,6 @@ dependencies = [
  "arrayvec",
  "num-traits",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -3039,6 +3064,7 @@ dependencies = [
  "once_cell",
  "ratatui",
  "regex",
+ "reqwest",
  "self_update",
  "serde",
  "serde_json",
@@ -3506,6 +3532,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff8b58f22cae39a24a26289da003ac87ddce0c024359c382d9ea0c48d08bc86"
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,7 +3570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
@@ -3691,27 +3738,24 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4440,7 +4484,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -4482,15 +4526,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"
@@ -4803,6 +4838,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5357,7 +5403,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "hmac",
  "indexmap",
  "lzma-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ async-trait = "0.1"
 tokio = { version = "1.47.1", features = ["fs", "macros", "rt-multi-thread", "io-util"] }
 tokio-stream = { version = "0.1.17", features = ["fs"] }
 futures = "0.3.31"
+reqwest = { version = "0.12.24", features = ["json", "rustls-tls", "cookies"] }
 
 [target.'cfg(windows)'.dependencies]
 winres = "0.1.12"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,24 @@
 #[cfg(target_os = "windows")]
 fn main() {
+    // windows icon
     let mut res = winres::WindowsResource::new();
     res.set_icon("assets/scout4all.ico");
     res.compile().unwrap();
+
+    // inject env vars
+    inject_env_vars();
 }
 
 #[cfg(not(target_os = "windows"))]
-fn main() {}
+fn main() {
+    inject_env_vars();
+}
+
+fn inject_env_vars() {
+    if let Ok(token) = std::env::var("LINEAR_TOKEN") {
+        println!("cargo:rustc-env=LINEAR_TOKEN={}", token);
+    }
+    if let Ok(team_id) = std::env::var("LINEAR_TEAM_ID") {
+        println!("cargo:rustc-env=LINEAR_TEAM_ID={}", team_id);
+    }
+}

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -22,6 +22,7 @@ pub struct Labels {
     pub name: &'static str,
     pub number: &'static str,
     pub name_cannot_be_empty: &'static str,
+    pub description_cannot_be_empty: &'static str,
     pub role_is_required: &'static str,
     pub could_not_create_player: &'static str,
     pub number_must_be_between_0_and_99: &'static str,
@@ -203,6 +204,13 @@ pub struct Labels {
     pub created_with: &'static str,
     pub print_report: &'static str,
     pub could_not_open_pdf: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    pub email: &'static str,
+    pub report_an_issue: &'static str,
+    pub issue_reported_successfully: &'static str,
+    pub failed_to_report_issue: &'static str,
+    pub invalid_email_address: &'static str,
 }
 
 const EN: Labels = Labels {
@@ -224,6 +232,7 @@ const EN: Labels = Labels {
     name: "name",
     number: "number",
     name_cannot_be_empty: "name cannot be empty",
+    description_cannot_be_empty: "description cannot be empty",
     role_is_required: "role is required",
     could_not_create_player: "could not create player",
     number_must_be_between_0_and_99: "number must be between 0 and 99",
@@ -405,6 +414,13 @@ const EN: Labels = Labels {
     created_with: "created with",
     print_report: "print report",
     could_not_open_pdf: "could not open PDF file",
+    title: "title",
+    description: "description",
+    email: "email",
+    report_an_issue: "report an issue",
+    issue_reported_successfully: "issue reported successfully",
+    failed_to_report_issue: "failed to report issue (check your internet connection)",
+    invalid_email_address: "invalid email address",
 };
 
 const IT: Labels = Labels {
@@ -426,6 +442,7 @@ const IT: Labels = Labels {
     name: "nome",
     number: "numero",
     name_cannot_be_empty: "il nome è obbligatorio",
+    description_cannot_be_empty: "la descrizione è obbligatoria",
     role_is_required: "il ruolo è obbligatorio",
     could_not_create_player: "impossibile creare il giocatore",
     number_must_be_between_0_and_99: "il numero deve essere compreso tra 0 e 99",
@@ -607,6 +624,13 @@ const IT: Labels = Labels {
     created_with: "creato con",
     print_report: "stampa tabellino",
     could_not_open_pdf: "impossibile aprire il file PDF",
+    title: "titolo",
+    description: "descrizione",
+    email: "email",
+    report_an_issue: "segnala un problema",
+    issue_reported_successfully: "problema segnalato con successo",
+    failed_to_report_issue: "segnalazione del problema non riuscita (controlla la tua connessione a internet)",
+    invalid_email_address: "indirizzo email non valido",
 };
 
 static DICTIONARY: Lazy<HashMap<LanguageEnum, &'static Labels>> = Lazy::new(|| {

--- a/src/screens/components/text_box.rs
+++ b/src/screens/components/text_box.rs
@@ -4,14 +4,19 @@ use ratatui::{
     widgets::Paragraph,
     Frame,
 };
-use std::fmt::Debug;
-use std::fmt::Formatter;
+use std::{
+    fmt::{Debug, Formatter},
+    time::{Duration, Instant},
+};
 
 pub struct TextBox {
     value: String,
     pub writing_mode: bool,
     label: String,
     pub validator: Box<dyn Fn(&str, char) -> bool + Send + Sync + 'static>,
+    pub multiline: bool,
+    last_blink: Instant,
+    show_cursor: bool,
 }
 
 impl Debug for TextBox {
@@ -27,14 +32,19 @@ impl Debug for TextBox {
 impl TextBox {
     pub fn new(label: String, writing_mode: bool, value: Option<&str>) -> Self {
         Self {
-            value: match value {
-                Some(v) => v.to_string(),
-                None => String::new(),
-            },
+            value: value.unwrap_or_default().to_string(),
             writing_mode,
             label,
             validator: Box::new(|_, _| true),
+            multiline: false,
+            last_blink: Instant::now(),
+            show_cursor: true,
         }
+    }
+
+    pub fn enable_multiline(mut self, enabled: bool) -> Self {
+        self.multiline = enabled;
+        self
     }
 
     pub fn with_validator<F>(
@@ -47,29 +57,45 @@ impl TextBox {
         F: Fn(&str, char) -> bool + Send + Sync + 'static,
     {
         Self {
-            value: match value {
-                Some(v) => v.to_string(),
-                None => String::new(),
-            },
+            value: value.unwrap_or_default().to_string(),
             writing_mode,
             label,
             validator: Box::new(validator),
+            multiline: false,
+            last_blink: Instant::now(),
+            show_cursor: true,
         }
     }
 
-    pub fn render(&self, f: &mut Frame, area: Rect) {
-        let widget =
-            Paragraph::new(format!("{}: {}", self.label, self.value)).style(if self.writing_mode {
-                Style::default().add_modifier(Modifier::REVERSED)
-            } else {
-                Style::default()
-            });
+    pub fn render(&mut self, f: &mut Frame, area: Rect) {
+        if self.last_blink.elapsed() >= Duration::from_millis(500) {
+            self.show_cursor = !self.show_cursor;
+            self.last_blink = Instant::now();
+        }
+        let mut content = if self.multiline {
+            format!("{}:\n{}", self.label, self.value)
+        } else {
+            format!("{}: {}", self.label, self.value)
+        };
+        if self.writing_mode && self.show_cursor {
+            content.push('█');
+        }
+        let widget = Paragraph::new(content).style(if self.writing_mode {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default()
+        });
         f.render_widget(widget, area);
     }
 
     pub fn handle_char(&mut self, c: char) {
-        if self.writing_mode && self.validator.as_ref()(&self.value, c) {
-            self.value.push(c);
+        if self.writing_mode {
+            if c == '\n' && !self.multiline {
+                return;
+            }
+            if (self.validator)(&self.value, c) {
+                self.value.push(c);
+            }
         }
     }
 
@@ -80,6 +106,6 @@ impl TextBox {
     }
 
     pub fn get_selected_value(&self) -> Option<String> {
-        self.value.clone().into()
+        Some(self.value.clone())
     }
 }

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -9,6 +9,7 @@ pub mod import_match_screen;
 pub mod import_team_screen;
 pub mod match_list_screen;
 pub mod match_stats_screen;
+pub mod report_an_issue_screen;
 pub mod scouting_screen;
 pub mod screen;
 pub mod settings_screen;

--- a/src/screens/report_an_issue_screen.rs
+++ b/src/screens/report_an_issue_screen.rs
@@ -1,0 +1,285 @@
+use crate::{
+    localization::current_labels,
+    screens::{
+        components::{
+            navigation_footer::NavigationFooter, notify_banner::NotifyBanner, text_box::TextBox,
+        },
+        screen::{AppAction, Renderable, ScreenAsync},
+    },
+};
+use async_trait::async_trait;
+use crossterm::event::{KeyCode, KeyEvent};
+use once_cell::sync::Lazy;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    widgets::{Block, Borders},
+    Frame,
+};
+use regex::Regex;
+use serde_json::json;
+
+static EMAIL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^[a-z0-9._%+-]+@[a-z0-9.-]*$").unwrap());
+
+fn email_validator(current: &str, c: char) -> bool {
+    if !c.is_ascii_alphanumeric() && !"@._%+-".contains(c) {
+        return false;
+    }
+    let mut s = current.to_string();
+    s.push(c);
+    true
+}
+
+#[derive(Debug)]
+pub struct ReportAnIssueScreen {
+    title: TextBox,
+    description: TextBox,
+    name: TextBox,
+    email: TextBox,
+    field: usize,
+    notify_message: NotifyBanner,
+    back: bool,
+    footer: NavigationFooter,
+    footer_entries: Vec<(String, String)>,
+}
+
+impl Renderable for ReportAnIssueScreen {
+    fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
+        let area = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(3), // 0: title
+                Constraint::Length(6), // 1: description
+                Constraint::Length(3), // 2: name
+                Constraint::Length(3), // 3: email
+                Constraint::Min(1),
+            ])
+            .split(body);
+        self.notify_message.render(f, footer_right);
+        self.render_header(f, body);
+        self.title.render(f, area[0]);
+        self.description.render(f, area[1]);
+        self.name.render(f, area[2]);
+        self.email.render(f, area[3]);
+        self.footer
+            .render(f, footer_left, self.footer_entries.clone());
+    }
+}
+
+#[async_trait]
+impl ScreenAsync for ReportAnIssueScreen {
+    async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
+        match (key.code, &self.notify_message.has_value()) {
+            (_, true) => self.handle_error_reset(),
+            (KeyCode::Char(c), _) => self.handle_char(c),
+            (KeyCode::Backspace, _) => self.handle_backspace(),
+            (KeyCode::Tab, _) => self.handle_tab(),
+            (KeyCode::BackTab, _) => self.handle_backtab(),
+            (KeyCode::Esc, _) => AppAction::Back(true, Some(1)),
+            (KeyCode::Enter, _) => {
+                if self.field == 1 {
+                    self.description.handle_char('\n');
+                    AppAction::None
+                } else {
+                    self.handle_enter().await
+                }
+            }
+            _ => AppAction::None,
+        }
+    }
+
+    async fn refresh_data(&mut self) {}
+}
+
+impl ReportAnIssueScreen {
+    pub fn new() -> Self {
+        let title = TextBox::new(current_labels().title.to_owned(), true, None);
+        let description = TextBox::new(current_labels().description.to_owned(), false, None)
+            .enable_multiline(true);
+        let name = TextBox::new(current_labels().name.to_owned(), false, None);
+        let email = TextBox::with_validator(
+            current_labels().email.to_owned(),
+            false,
+            None,
+            email_validator,
+        );
+        ReportAnIssueScreen {
+            title,
+            description,
+            name,
+            email,
+            field: 0,
+            notify_message: NotifyBanner::new(),
+            back: false,
+            footer: NavigationFooter::new(),
+            footer_entries: vec![
+                (
+                    "Tab / Shift+Tab".to_string(),
+                    current_labels().switch_field.to_string(),
+                ),
+                (
+                    current_labels().enter.to_string(),
+                    current_labels().confirm.to_string(),
+                ),
+                ("Esc".to_string(), current_labels().back.to_string()),
+                ("Q".to_string(), current_labels().quit.to_string()),
+            ],
+        }
+    }
+
+    fn handle_error_reset(&mut self) -> AppAction {
+        self.notify_message.reset();
+        if self.back {
+            AppAction::Back(true, Some(1))
+        } else {
+            AppAction::None
+        }
+    }
+
+    fn handle_tab(&mut self) -> AppAction {
+        self.field = (self.field + 1) % 4;
+        self.update_writing_modes();
+        AppAction::None
+    }
+
+    fn handle_backtab(&mut self) -> AppAction {
+        self.field = (self.field + 3) % 4;
+        self.update_writing_modes();
+        AppAction::None
+    }
+
+    fn update_writing_modes(&mut self) {
+        self.title.writing_mode = self.field == 0;
+        self.description.writing_mode = self.field == 1;
+        self.name.writing_mode = self.field == 2;
+        self.email.writing_mode = self.field == 3;
+    }
+
+    fn handle_backspace(&mut self) -> AppAction {
+        self.title.handle_backspace();
+        self.description.handle_backspace();
+        self.name.handle_backspace();
+        self.email.handle_backspace();
+        AppAction::None
+    }
+
+    async fn handle_enter(&mut self) -> AppAction {
+        match (
+            self.field,
+            self.title.get_selected_value(),
+            self.description.get_selected_value(),
+            self.name.get_selected_value(),
+            self.email.get_selected_value(),
+        ) {
+            (0, _, _, _, _) => AppAction::None,
+            (_, None, _, _, _) => {
+                self.notify_message
+                    .set_error(current_labels().name_cannot_be_empty.to_string());
+                AppAction::None
+            }
+            (_, _, None, _, _) => {
+                self.notify_message
+                    .set_error(current_labels().description_cannot_be_empty.to_string());
+                AppAction::None
+            }
+            (_, Some(title), Some(description), _, _) => {
+                let mut full_description = description.to_string();
+                if let Some(name) = self.name.get_selected_value() {
+                    if !name.is_empty() {
+                        full_description.push_str(&format!("\n\nname: {}", name));
+                    }
+                }
+                if let Some(email) = self.email.get_selected_value() {
+                    if !email.is_empty() {
+                        full_description.push_str(&format!("\ne-mail: {}", email));
+                    } else if !EMAIL_RE.is_match(&email) {
+                        self.notify_message
+                            .set_error(current_labels().invalid_email_address.to_string());
+                        return AppAction::None;
+                    }
+                }
+                let result = self
+                    .send_issue(title.as_str(), full_description.as_str())
+                    .await;
+                match result {
+                    Ok(_) => {
+                        self.notify_message
+                            .set_info(current_labels().issue_reported_successfully.to_string());
+                        self.back = true;
+                    }
+                    Err(_) => {
+                        self.notify_message
+                            .set_error(current_labels().failed_to_report_issue.to_string());
+                    }
+                }
+                AppAction::None
+            }
+        }
+    }
+
+    fn handle_char(&mut self, c: char) -> AppAction {
+        self.title.handle_char(c);
+        self.description.handle_char(c);
+        self.name.handle_char(c);
+        self.email.handle_char(c);
+        AppAction::None
+    }
+
+    fn render_header(&self, f: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(current_labels().report_an_issue);
+        f.render_widget(block, area);
+    }
+
+    async fn send_issue(&self, title: &str, description: &str) -> Result<(), String> {
+        const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
+        let token = std::env::var("LINEAR_TOKEN").unwrap_or_default();
+        let team_id = std::env::var("LINEAR_TEAM_ID").unwrap_or_default();
+        let client = reqwest::Client::new();
+        let query = r#"
+            mutation CreateIssue($input: IssueCreateInput!) {
+                issueCreate(input: $input) {
+                    success
+                    issue {
+                        id
+                        identifier
+                        title
+                        description
+                    }
+                }
+            }
+        "#;
+        let body = json!({
+            "query": query,
+            "variables": {
+                "input": {
+                    "title": title,
+                    "description": description,
+                    "teamId": team_id
+                }
+            }
+        });
+        let response = client
+            .post(LINEAR_API_URL)
+            .header("Authorization", token)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Network error: {}", e))?;
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(format!("http error {}: {}", status, text));
+        }
+        let json: serde_json::Value =
+            serde_json::from_str(&text).map_err(|e| format!("invalid json response: {}", e))?;
+        if json["data"]["issueCreate"]["success"] == true {
+            Ok(())
+        } else {
+            Err(format!("failed to create issue: {}", json))
+        }
+    }
+}

--- a/src/screens/settings_screen.rs
+++ b/src/screens/settings_screen.rs
@@ -5,6 +5,7 @@ use crate::{
     providers::settings_writer::SettingsWriter,
     screens::{
         components::{navigation_footer::NavigationFooter, notify_banner::NotifyBanner},
+        report_an_issue_screen::ReportAnIssueScreen,
         screen::{AppAction, Renderable, ScreenAsync},
     },
     shapes::{enums::LanguageEnum, settings::Settings},
@@ -63,6 +64,9 @@ impl<SW: SettingsWriter + Send + Sync> ScreenAsync for SettingsScreen<SW> {
             (KeyCode::Up, _) => self.handle_up(),
             (KeyCode::Down, _) => self.handle_down(),
             (KeyCode::Esc, _) => AppAction::Back(true, Some(1)),
+            (KeyCode::Char('i'), _) => {
+                AppAction::SwitchScreen(Box::new(ReportAnIssueScreen::new()))
+            }
             (KeyCode::Enter, _) => self.handle_enter().await,
             _ => AppAction::None,
         }
@@ -89,6 +93,10 @@ impl<SW: SettingsWriter + Send + Sync> SettingsScreen<SW> {
                 (
                     current_labels().enter.to_string(),
                     current_labels().confirm.to_string(),
+                ),
+                (
+                    "I".to_string(),
+                    current_labels().report_an_issue.to_string(),
                 ),
                 ("Esc".to_string(), current_labels().back.to_string()),
                 ("Q".to_string(), current_labels().quit.to_string()),


### PR DESCRIPTION
The idea is to allow users to report issues directly from the application.  

We wanted to avoid using github itself for this, since we use it primarily as a backlog. Issues can be written in different languages and do not necessarily come from users with a computer science background. Reports collected from the application need to be properly refined, translated and converted into github issues before they can be worked on.  
After some research, I identified [linear](https://linear.app/) as a suitable provider, which offers GraphQL APIs and does not impose significant limits on the free plan (I believe it allows up to 250 open issues simultaneously).  
This PR introduces the ability to report an issue from the settings screen, where the user can access the reporting form by pressing `i`.
The form includes the following fields: "_title_" (required), "_description_" (required), "_name_" (optional) and "e-mail" (optional).  
For the API key and team ID required by the API, a secret (`LINEAR_TOKEN`) and a github variable (`LINEAR_TEAM_ID`) have been added. The secret's scope is limited to issue creation and both values are injected at build time as environment variables.  
Currently, there is no user interaction after submission (e.g. tracking the issue).