### PR TITLE
Add anonymous analytics data upload system

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
           LINEAR_TEAM_ID: ${{ vars.LINEAR_TEAM_ID }}
+          ANALYTICS_UPLOAD_URL: ${{ vars.ANALYTICS_UPLOAD_URL }}
       - name: setup variables
         id: variables
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,11 +209,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -271,9 +271,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
 ]
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -657,7 +657,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -673,7 +673,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio 1.0.4",
  "parking_lot",
@@ -710,21 +710,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -1795,9 +1795,9 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -1820,9 +1820,12 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "inout"
@@ -1864,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1958,7 +1961,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall",
 ]
@@ -2069,9 +2072,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -2218,9 +2221,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -2228,7 +2231,7 @@ version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2341,7 +2344,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2451,7 +2454,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2508,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2719,7 +2722,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2770,7 +2773,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2940,7 +2943,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2953,7 +2956,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2962,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
  "log",
  "once_cell",
@@ -3008,7 +3011,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -3085,7 +3088,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3225,6 +3228,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -3475,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3537,7 +3546,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3877,7 +3886,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -4104,7 +4113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722b0d6dfd05aa5bb7da7f282586f624f452e3f285cd3a10ac0d7e99f3bc3048"
 dependencies = [
  "az",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bumpalo",
  "chinese-number",
  "ciborium",
@@ -4318,9 +4327,9 @@ checksum = "260bc6647b3893a9a90668360803a15f96b85a5257b1c3a0c3daf6ae2496de42"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "unicode-math-class"
@@ -4487,6 +4496,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -4658,7 +4668,7 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "indexmap",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0"
 dirs = "5.0"
 crossterm = "0.27"
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 regex = "1"
 csv = "1"
 once_cell = "1.21.3"

--- a/build.rs
+++ b/build.rs
@@ -21,4 +21,7 @@ fn inject_env_vars() {
     if let Ok(team_id) = std::env::var("LINEAR_TEAM_ID") {
         println!("cargo:rustc-env=LINEAR_TEAM_ID={}", team_id);
     }
+    if let Ok(url) = std::env::var("ANALYTICS_UPLOAD_URL") {
+        println!("cargo:rustc-env=ANALYTICS_UPLOAD_URL={}", url);
+    }
 }

--- a/src/analytics/global.rs
+++ b/src/analytics/global.rs
@@ -1,0 +1,56 @@
+use crate::{
+    analytics::queue_manager::QueueManager,
+    errors::AppError,
+    providers::{queue_reader::QueueReader, queue_writer::QueueWriter},
+};
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+use uuid::Uuid;
+
+static GLOBAL_QUEUE_MANAGER: OnceCell<Arc<dyn GlobalQueueManager>> = OnceCell::new();
+
+#[async_trait::async_trait]
+pub trait GlobalQueueManager: Send + Sync {
+    async fn enqueue(&self, team_id: Uuid, match_id: String) -> Result<(), AppError>;
+}
+
+struct QueueManagerWrapper<
+    QR: QueueReader + Send + Sync + 'static,
+    QW: QueueWriter + Send + Sync + 'static,
+> {
+    inner: Arc<QueueManager<QR, QW>>,
+}
+
+#[async_trait::async_trait]
+impl<QR: QueueReader + Send + Sync + 'static, QW: QueueWriter + Send + Sync + 'static>
+    GlobalQueueManager for QueueManagerWrapper<QR, QW>
+{
+    async fn enqueue(&self, team_id: Uuid, match_id: String) -> Result<(), AppError> {
+        self.inner.enqueue(team_id, match_id).await
+    }
+}
+
+// initialize the global queue manager
+pub fn init_global_queue_manager<
+    QR: QueueReader + Send + Sync + 'static,
+    QW: QueueWriter + Send + Sync + 'static,
+>(
+    queue_manager: Arc<QueueManager<QR, QW>>,
+) -> Result<(), String> {
+    let wrapper = QueueManagerWrapper {
+        inner: queue_manager,
+    };
+    GLOBAL_QUEUE_MANAGER
+        .set(Arc::new(wrapper))
+        .map_err(|_| "Global queue manager already initialized".to_string())
+}
+
+// enqueue a match for upload (thread-safe, uses global queue manager)
+pub async fn enqueue_match_for_upload(team_id: Uuid, match_id: String) -> Result<(), AppError> {
+    match GLOBAL_QUEUE_MANAGER.get() {
+        Some(manager) => manager.enqueue(team_id, match_id).await,
+        None => Err(AppError::IO(crate::errors::IOError::Msg(
+            "Queue manager not initialized".to_string(),
+        ))),
+    }
+}

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -1,0 +1,4 @@
+pub mod global;
+pub mod queue;
+pub mod queue_manager;
+pub mod upload;

--- a/src/analytics/queue.rs
+++ b/src/analytics/queue.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PendingUpload {
+    pub team_id: Uuid,
+    pub match_id: String,
+    pub queued_at: i64, // timestamp
+    pub retry_count: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct UploadQueue {
+    pending: Vec<PendingUpload>,
+}
+
+impl UploadQueue {
+    // add match to upload queue
+    pub fn enqueue(&mut self, team_id: Uuid, match_id: String) {
+        // avoid duplicates
+        if self.pending.iter().any(|p| p.match_id == match_id) {
+            return;
+        }
+        self.pending.push(PendingUpload {
+            team_id,
+            match_id,
+            queued_at: chrono::Utc::now().timestamp(),
+            retry_count: 0,
+        });
+    }
+
+    // get next item to process
+    pub fn peek(&self) -> Option<&PendingUpload> {
+        self.pending.first()
+    }
+
+    // remove successfully uploaded match
+    pub fn dequeue(&mut self, match_id: &str) {
+        self.pending.retain(|p| p.match_id != match_id);
+    }
+
+    // increment retry counter for failed upload
+    pub fn mark_retry(&mut self, match_id: &str) {
+        if let Some(item) = self.pending.iter_mut().find(|p| p.match_id == match_id) {
+            item.retry_count += 1;
+        }
+    }
+
+    // check if queue is empty
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}

--- a/src/analytics/queue_manager.rs
+++ b/src/analytics/queue_manager.rs
@@ -1,0 +1,60 @@
+use crate::{
+    analytics::queue::UploadQueue,
+    errors::AppError,
+    providers::{queue_reader::QueueReader, queue_writer::QueueWriter},
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+// thread-safe queue manager to prevent race conditions
+pub struct QueueManager<
+    QR: QueueReader + Send + Sync + 'static,
+    QW: QueueWriter + Send + Sync + 'static,
+> {
+    queue_reader: Arc<QR>,
+    queue_writer: Arc<QW>,
+    lock: Arc<Mutex<()>>,
+}
+
+impl<QR: QueueReader + Send + Sync + 'static, QW: QueueWriter + Send + Sync + 'static>
+    QueueManager<QR, QW>
+{
+    pub fn new(queue_reader: Arc<QR>, queue_writer: Arc<QW>) -> Self {
+        Self {
+            queue_reader,
+            queue_writer,
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    // enqueue a match for upload (thread-safe)
+    pub async fn enqueue(&self, team_id: Uuid, match_id: String) -> Result<(), AppError> {
+        let _ = self.lock.lock().await;
+        let mut queue = self.queue_reader.load().await?;
+        queue.enqueue(team_id, match_id);
+        self.queue_writer.save(&queue).await
+    }
+
+    // load queue (thread-safe)
+    pub async fn load(&self) -> Result<UploadQueue, AppError> {
+        let _ = self.lock.lock().await;
+        self.queue_reader.load().await
+    }
+
+    // remove successfully uploaded match (thread-safe)
+    pub async fn dequeue(&self, match_id: &str) -> Result<(), AppError> {
+        let _ = self.lock.lock().await;
+        let mut queue = self.queue_reader.load().await?;
+        queue.dequeue(match_id);
+        self.queue_writer.save(&queue).await
+    }
+
+    // mark retry for failed upload (thread-safe)
+    pub async fn mark_retry(&self, match_id: &str) -> Result<(), AppError> {
+        let _ = self.lock.lock().await;
+        let mut queue = self.queue_reader.load().await?;
+        queue.mark_retry(match_id);
+        self.queue_writer.save(&queue).await
+    }
+}

--- a/src/analytics/upload.rs
+++ b/src/analytics/upload.rs
@@ -1,0 +1,324 @@
+use crate::{
+    analytics::queue_manager::QueueManager,
+    errors::{AppError, IOError},
+    logging::logger::{log_error, log_info},
+    providers::{
+        fs::path::{get_set_descriptor_file_path, get_set_events_file_path},
+        match_reader::MatchReader,
+        queue_reader::QueueReader,
+        queue_writer::QueueWriter,
+        team_reader::TeamReader,
+    },
+    shapes::{
+        enums::{GenderEnum, TeamClassificationEnum},
+        r#match::MatchEntry,
+    },
+};
+use futures::TryFutureExt;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::to_string_pretty;
+use std::{
+    env::{temp_dir, var},
+    fs::remove_file,
+    io::Write,
+    path::Path,
+    time::Duration,
+};
+use std::{path::PathBuf, sync::Arc};
+use tokio::time::interval;
+use tokio::{fs::File, io::AsyncReadExt};
+use tokio::{spawn, task::JoinHandle};
+use uuid::Uuid;
+use zip::{write::FileOptions, CompressionMethod, ZipWriter};
+
+#[derive(Debug, Serialize)]
+pub struct UploadRequest {
+    pub filename: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MatchMetadata {
+    pub date: String,
+    pub home: bool,
+    pub team_id: Uuid,
+    pub gender: Option<GenderEnum>,
+    pub year: u16,
+    pub classification: Option<TeamClassificationEnum>,
+}
+
+// generate a deterministic UUID v5 from team_id and match_id
+fn generate_upload_id(team_id: Uuid, match_id: &str) -> Uuid {
+    // custom namespace for our application
+    const NAMESPACE: Uuid = Uuid::from_bytes([
+        0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30,
+        0xc8,
+    ]);
+    let name = format!("{}:{}", team_id, match_id);
+    Uuid::new_v5(&NAMESPACE, name.as_bytes())
+}
+
+// upload file to signed URL using PUT
+async fn upload_file_to_signed_url(signed_url: &str, file_path: &Path) -> Result<(), AppError> {
+    let mut file = File::open(file_path)
+        .await
+        .map_err(|e| AppError::IO(IOError::from(e)))?;
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)
+        .await
+        .map_err(|e| AppError::IO(IOError::from(e)))?;
+    let client = Client::new();
+    let response = client
+        .put(signed_url)
+        .header("Content-Type", "application/zip")
+        .body(contents)
+        .send()
+        .await
+        .map_err(|e| AppError::IO(IOError::from(e)))?;
+    if response.status().is_success() {
+        log_info(format!("uploaded file to signed URL '{}'", signed_url).as_str());
+        Ok(())
+    } else {
+        let message = format!(
+            "could not upload file: server returned unexpected status code ({})",
+            response.status()
+        );
+        log_error(&message);
+        Err(AppError::IO(IOError::Msg(message)))
+    }
+}
+
+// create a ZIP archive with match data and set files
+async fn create_match_archive(
+    m: &MatchEntry,
+    base_path: &Path,
+    zip_path: &Path,
+) -> Result<(), AppError> {
+    let file = std::fs::File::create(zip_path).map_err(|e| AppError::IO(IOError::from(e)))?;
+    let mut zip = ZipWriter::new(file);
+    let metadata = MatchMetadata {
+        date: m.date.to_string(),
+        home: m.home,
+        team_id: m.team.id,
+        gender: m.team.gender,
+        year: m.team.year,
+        classification: m.team.classification,
+    };
+    let metadata_json = to_string_pretty(&metadata).map_err(|e| AppError::IO(IOError::from(e)))?;
+    zip.start_file::<_, ()>(
+        "match.json",
+        FileOptions::default().compression_method(CompressionMethod::Deflated),
+    )
+    .map_err(|e| AppError::IO(IOError::from(e)))?;
+    zip.write_all(metadata_json.as_bytes())
+        .map_err(|e| AppError::IO(IOError::from(e)))?;
+    // add set files
+    for set in &m.sets {
+        let set_descriptor_path =
+            get_set_descriptor_file_path(base_path, &m.team.id, &m.id, set.set_number)?;
+        let set_events_path =
+            get_set_events_file_path(base_path, &m.team.id, &m.id, set.set_number)?;
+        // descriptor
+        if set_descriptor_path.exists() {
+            let mut file = File::open(&set_descriptor_path)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+            let mut contents = Vec::new();
+            file.read_to_end(&mut contents)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+            let filename = format!("set_{}_descriptor.json", set.set_number);
+            zip.start_file::<_, ()>(
+                &filename,
+                FileOptions::default().compression_method(CompressionMethod::Deflated),
+            )
+            .map_err(|e| AppError::IO(IOError::from(e)))?;
+            zip.write_all(&contents)
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+        }
+        // events
+        if set_events_path.exists() {
+            let mut file = File::open(&set_events_path)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+            let mut contents = Vec::new();
+            file.read_to_end(&mut contents)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+            let filename = format!("set_{}_events.csv", set.set_number);
+            zip.start_file::<_, ()>(
+                &filename,
+                FileOptions::default().compression_method(CompressionMethod::Deflated),
+            )
+            .map_err(|e| AppError::IO(IOError::from(e)))?;
+            zip.write_all(&contents)
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+        }
+    }
+    zip.finish().map_err(|e| AppError::IO(IOError::from(e)))?;
+    Ok(())
+}
+
+// retrieve signed URL for sending analytics data
+async fn get_signed_url(m: &MatchEntry) -> Result<(String, Uuid), AppError> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .map_err(|e| AppError::IO(IOError::from(e)))?;
+    let uuid = generate_upload_id(m.team.id, m.id.as_str());
+    let payload = UploadRequest {
+        filename: format!("{}.zip", uuid),
+    };
+    let analytics_upload_url = var("ANALYTICS_UPLOAD_URL")
+        .map_err(|_| AppError::IO(IOError::Msg("could not get analytics upload url".into())))?;
+    let response = client
+        .post(analytics_upload_url)
+        .json(&payload)
+        .send()
+        .map_err(|e| AppError::IO(IOError::from(e)))
+        .await?;
+    if response.status() != StatusCode::CREATED {
+        let message = format!(
+            "could not retrieve upload signed URL: unexpected status code ({})",
+            response.status()
+        );
+        log_error(&message);
+        Err(AppError::IO(IOError::Msg(message)))
+    } else {
+        let signed_url = response
+            .headers()
+            .get("Location")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(AppError::IO(IOError::Msg("missing Location header".into())))?
+            .to_string();
+        log_info(
+            format!(
+                "generated signed URL '{}' for file '{}.zip'",
+                signed_url, uuid
+            )
+            .as_str(),
+        );
+        Ok((signed_url, uuid))
+    }
+}
+
+pub struct AnalyticsUploadWorker<
+    TR: TeamReader + Send + Sync + 'static,
+    MR: MatchReader + Send + Sync + 'static,
+    QR: QueueReader + Send + Sync + 'static,
+    QW: QueueWriter + Send + Sync + 'static,
+> {
+    base_path: PathBuf,
+    team_reader: Arc<TR>,
+    match_reader: Arc<MR>,
+    queue_manager: Arc<QueueManager<QR, QW>>,
+    polling_interval: Duration,
+}
+
+impl<
+        TR: TeamReader + Send + Sync + 'static,
+        MR: MatchReader + Send + Sync + 'static,
+        QR: QueueReader + Send + Sync + 'static,
+        QW: QueueWriter + Send + Sync + 'static,
+    > AnalyticsUploadWorker<TR, MR, QR, QW>
+{
+    pub fn new(
+        base_path: PathBuf,
+        team_reader: Arc<TR>,
+        match_reader: Arc<MR>,
+        queue_reader: Arc<QR>,
+        queue_writer: Arc<QW>,
+        polling_interval: Duration,
+    ) -> Self {
+        let queue_manager = Arc::new(QueueManager::new(queue_reader, queue_writer));
+        Self {
+            base_path,
+            team_reader,
+            match_reader,
+            queue_manager,
+            polling_interval,
+        }
+    }
+
+    // get a reference to the queue manager (for enqueuing from other parts of the app)
+    pub fn queue_manager(&self) -> Arc<QueueManager<QR, QW>> {
+        Arc::clone(&self.queue_manager)
+    }
+
+    // start background worker that processes upload queue
+    pub fn start(&self) -> JoinHandle<()> {
+        let base_path = self.base_path.clone();
+        let polling_interval = self.polling_interval;
+        let team_reader = self.team_reader.clone();
+        let match_reader = self.match_reader.clone();
+        let queue_manager = self.queue_manager.clone();
+
+        spawn(async move {
+            let mut ticker = interval(polling_interval);
+            loop {
+                ticker.tick().await;
+                let _ = async {
+                    let queue = queue_manager.load().await.ok()?;
+                    if queue.is_empty() {
+                        return Some(());
+                    }
+                    // process first item
+                    let pending = queue.peek().cloned()?;
+                    match load_match_from_disk(
+                        Arc::clone(&team_reader),
+                        Arc::clone(&match_reader),
+                        &pending.team_id,
+                        &pending.match_id,
+                    )
+                    .await
+                    {
+                        Ok(match_entry) => {
+                            // upload attempt
+                            if process_single_upload(&match_entry, &base_path)
+                                .await
+                                .is_ok()
+                            {
+                                // success
+                                let _ = queue_manager.dequeue(&pending.match_id).await;
+                            } else {
+                                // failure: just mark retry, keep in queue indefinitely
+                                let _ = queue_manager.mark_retry(&pending.match_id).await;
+                            }
+                        }
+                        Err(_) => {
+                            // match not found
+                            let _ = queue_manager.dequeue(&pending.match_id).await;
+                        }
+                    }
+                    Some(())
+                }
+                .await;
+            }
+        })
+    }
+}
+
+// process a single upload
+async fn process_single_upload(m: &MatchEntry, base_path: &Path) -> Result<(), AppError> {
+    let (signed_url, uuid) = get_signed_url(m).await?;
+    let temp_dir = temp_dir();
+    let zip_path = temp_dir.join(format!("{}.zip", uuid));
+    create_match_archive(m, base_path, &zip_path).await?;
+    let result = upload_file_to_signed_url(&signed_url, &zip_path).await;
+    let _ = remove_file(&zip_path);
+    result
+}
+
+// helper to load match from disk
+async fn load_match_from_disk<
+    TR: TeamReader + Send + Sync + 'static,
+    MR: MatchReader + Send + Sync + 'static,
+>(
+    team_reader: Arc<TR>,
+    match_reader: Arc<MR>,
+    team_id: &Uuid,
+    match_id: &str,
+) -> Result<MatchEntry, AppError> {
+    let team = team_reader.read_single(team_id).await?;
+    match_reader.read_single(&team, match_id).await
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,8 @@ use std::{path::PathBuf, sync::Arc};
 use crate::{
     providers::{
         match_reader::MatchReader, match_writer::MatchWriter, set_writer::SetWriter,
-        settings_writer::SettingsWriter, team_reader::TeamReader, team_writer::TeamWriter,
+        settings_reader::SettingsReader, settings_writer::SettingsWriter, team_reader::TeamReader,
+        team_writer::TeamWriter,
     },
     screens::{screen::ScreenAsync, team_list_screen::TeamListScreen},
     shapes::{settings::Settings, team::TeamEntry},
@@ -21,6 +22,7 @@ impl App {
         MR: MatchReader + Send + Sync + 'static,
         MW: MatchWriter + Send + Sync + 'static,
         SSW: SetWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
     >(
         settings: Settings,
         teams: Vec<TeamEntry>,
@@ -31,6 +33,7 @@ impl App {
         set_writer: Arc<SSW>,
         match_reader: Arc<MR>,
         match_writer: Arc<MW>,
+        settings_reader: Arc<SR>,
     ) -> Self {
         Self {
             screens: vec![Box::new(TeamListScreen::new(
@@ -43,6 +46,7 @@ impl App {
                 match_reader,
                 match_writer,
                 set_writer,
+                settings_reader,
             ))],
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 pub const MATCH_DESCRIPTOR_FILE_NAME: &str = "match.json";
 pub const TEAM_DESCRIPTOR_FILE_NAME: &str = "team.json";
+pub const UPLOAD_QUEUE_FILE_NAME: &str = "upload_queue.json";
 pub const DEFAULT_SET_TARGET_SCORE: u8 = 25;
 pub const TIE_BREAK_SET_TARGET_SCORE: u8 = 15;
 pub const MAX_SUBSTITUTIONS: usize = 6;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,6 +35,8 @@ pub enum IOError {
     Io(#[from] std::io::Error),
     #[error("serde JSON error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+    #[error("reqwest error: {0}")]
+    Reqwest(#[from] reqwest::Error),
     #[error("{0}")]
     Msg(String),
     #[error("CSV error: {0}")]

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -216,6 +216,7 @@ pub struct Labels {
     pub failed_to_report_issue: &'static str,
     pub invalid_email_address: &'static str,
     pub y: &'static char,
+    pub enable_send_analytics: &'static str,
 }
 
 const EN: Labels = Labels {
@@ -430,7 +431,8 @@ const EN: Labels = Labels {
     issue_reported_successfully: "issue reported successfully",
     failed_to_report_issue: "failed to report issue (check your internet connection)",
     invalid_email_address: "invalid email address",
-    y: &'y'
+    y: &'y',
+    enable_send_analytics: "enable sending anonymous analytics data",
 };
 
 const IT: Labels = Labels {
@@ -645,7 +647,8 @@ const IT: Labels = Labels {
     issue_reported_successfully: "problema segnalato con successo",
     failed_to_report_issue: "segnalazione del problema non riuscita (controlla la tua connessione a internet)",
     invalid_email_address: "indirizzo email non valido",
-    y: &'s'
+    y: &'s',
+    enable_send_analytics: "abilita l'invio di dati analitici anonimi",
 };
 
 static DICTIONARY: Lazy<HashMap<LanguageEnum, &'static Labels>> = Lazy::new(|| {

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -1,0 +1,50 @@
+use chrono::Local;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+static LOGGER: once_cell::sync::Lazy<Mutex<Logger>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(Logger::new()));
+
+struct Logger {
+    path: Option<PathBuf>,
+}
+
+impl Logger {
+    fn new() -> Self {
+        Self { path: None }
+    }
+
+    fn initialize(&mut self, path: PathBuf) {
+        self.path = Some(path);
+    }
+
+    fn write(&self, level: &str, message: &str) {
+        if let Some(path) = &self.path {
+            let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+            let line = format!("[{}] {} - {}\n", timestamp, level, message);
+            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+                let _ = file.write_all(line.as_bytes());
+            }
+        }
+    }
+}
+
+pub fn init_logger(log_path: PathBuf) {
+    if let Ok(mut logger) = LOGGER.lock() {
+        logger.initialize(log_path);
+    }
+}
+
+pub fn log_info(message: &str) {
+    if let Ok(logger) = LOGGER.lock() {
+        logger.write("INFO", message);
+    }
+}
+
+pub fn log_error(message: &str) {
+    if let Ok(logger) = LOGGER.lock() {
+        logger.write("ERROR", message);
+    }
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,1 @@
+pub mod logger;

--- a/src/providers/fs/mod.rs
+++ b/src/providers/fs/mod.rs
@@ -1,6 +1,8 @@
 pub mod match_reader;
 pub mod match_writer;
 pub mod path;
+pub mod queue_reader;
+pub mod queue_writer;
 pub mod set_reader;
 pub mod set_writer;
 pub mod settings_reader;

--- a/src/providers/fs/queue_reader.rs
+++ b/src/providers/fs/queue_reader.rs
@@ -1,0 +1,31 @@
+use crate::{
+    analytics::queue::UploadQueue,
+    errors::{AppError, IOError},
+    providers::queue_reader::QueueReader,
+};
+use async_trait::async_trait;
+use serde_json::from_str;
+use std::path::{Path, PathBuf};
+use tokio::fs::read_to_string;
+
+pub struct FileSystemQueueReader(PathBuf);
+
+impl FileSystemQueueReader {
+    pub fn new(path: &Path) -> Self {
+        Self(path.to_path_buf())
+    }
+}
+
+#[async_trait]
+impl QueueReader for FileSystemQueueReader {
+    async fn load(&self) -> Result<UploadQueue, AppError> {
+        if !self.0.exists() {
+            Ok(UploadQueue::default())
+        } else {
+            let contents = read_to_string(&self.0)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+            from_str(&contents).map_err(|e| AppError::IO(IOError::from(e)))
+        }
+    }
+}

--- a/src/providers/fs/queue_writer.rs
+++ b/src/providers/fs/queue_writer.rs
@@ -1,0 +1,32 @@
+use crate::{
+    analytics::queue::UploadQueue,
+    errors::{AppError, IOError},
+    providers::queue_writer::QueueWriter,
+};
+use async_trait::async_trait;
+use serde_json::to_string_pretty;
+use std::path::{Path, PathBuf};
+use tokio::fs::{create_dir_all, write};
+
+pub struct FileSystemQueueWriter(PathBuf);
+
+impl FileSystemQueueWriter {
+    pub fn new(path: &Path) -> Self {
+        Self(path.to_path_buf())
+    }
+}
+
+#[async_trait]
+impl QueueWriter for FileSystemQueueWriter {
+    async fn save(&self, queue: &UploadQueue) -> Result<(), AppError> {
+        let contents = to_string_pretty(queue).map_err(|e| AppError::IO(IOError::from(e)))?;
+        if let Some(parent) = self.0.parent() {
+            create_dir_all(parent)
+                .await
+                .map_err(|e| AppError::IO(IOError::from(e)))?;
+        }
+        write(&self.0, contents)
+            .await
+            .map_err(|e| AppError::IO(IOError::from(e)))
+    }
+}

--- a/src/providers/fs/settings_writer.rs
+++ b/src/providers/fs/settings_writer.rs
@@ -19,8 +19,15 @@ impl FileSystemSettingsWriter {
 
 #[async_trait]
 impl SettingsWriter for FileSystemSettingsWriter {
-    async fn save(&self, language: LanguageEnum) -> Result<Settings, AppError> {
-        let config = Settings { language };
+    async fn save(
+        &self,
+        language: LanguageEnum,
+        analytics_enabled: bool,
+    ) -> Result<Settings, AppError> {
+        let config = Settings {
+            language,
+            analytics_enabled,
+        };
         let path = get_config_file_path(&self.0);
         let bytes = spawn_blocking({
             let config = config.clone();

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,6 +1,8 @@
 pub mod fs;
 pub mod match_reader;
 pub mod match_writer;
+pub mod queue_reader;
+pub mod queue_writer;
 pub mod set_reader;
 pub mod set_writer;
 pub mod settings_reader;

--- a/src/providers/queue_reader.rs
+++ b/src/providers/queue_reader.rs
@@ -1,0 +1,7 @@
+use crate::{analytics::queue::UploadQueue, errors::AppError};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait QueueReader {
+    async fn load(&self) -> Result<UploadQueue, AppError>;
+}

--- a/src/providers/queue_writer.rs
+++ b/src/providers/queue_writer.rs
@@ -1,0 +1,7 @@
+use crate::{analytics::queue::UploadQueue, errors::AppError};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait QueueWriter {
+    async fn save(&self, queue: &UploadQueue) -> Result<(), AppError>;
+}

--- a/src/providers/settings_writer.rs
+++ b/src/providers/settings_writer.rs
@@ -6,5 +6,9 @@ use async_trait::async_trait;
 
 #[async_trait]
 pub trait SettingsWriter {
-    async fn save(&self, language: LanguageEnum) -> Result<Settings, AppError>;
+    async fn save(
+        &self,
+        language: LanguageEnum,
+        analytics_enabled: bool,
+    ) -> Result<Settings, AppError>;
 }

--- a/src/screens/components/checkbox.rs
+++ b/src/screens/components/checkbox.rs
@@ -13,11 +13,11 @@ pub struct CheckBox {
 }
 
 impl CheckBox {
-    pub fn new(label: String, writing_mode: bool) -> Self {
+    pub fn new(label: String, writing_mode: bool, selected_value: bool) -> Self {
         Self {
             writing_mode,
             label,
-            value: false,
+            value: selected_value,
         }
     }
 

--- a/src/screens/report_an_issue_screen.rs
+++ b/src/screens/report_an_issue_screen.rs
@@ -1,3 +1,5 @@
+use std::env::var;
+
 use crate::{
     localization::current_labels,
     screens::{
@@ -235,8 +237,8 @@ impl ReportAnIssueScreen {
 
     async fn send_issue(&self, title: &str, description: &str) -> Result<(), String> {
         const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
-        let token = std::env::var("LINEAR_TOKEN").unwrap_or_default();
-        let team_id = std::env::var("LINEAR_TEAM_ID").unwrap_or_default();
+        let token = var("LINEAR_TOKEN").unwrap_or_default();
+        let team_id = var("LINEAR_TEAM_ID").unwrap_or_default();
         let client = reqwest::Client::new();
         let query = r#"
             mutation CreateIssue($input: IssueCreateInput!) {

--- a/src/screens/team_details_screen.rs
+++ b/src/screens/team_details_screen.rs
@@ -6,6 +6,7 @@ use crate::{
         match_reader::MatchReader,
         match_writer::MatchWriter,
         set_writer::SetWriter,
+        settings_reader::SettingsReader,
         team_reader::TeamReader,
         team_writer::{PlayerInput, TeamWriter},
     },
@@ -41,6 +42,7 @@ pub struct TeamDetailsScreen<
     MR: MatchReader + Send + Sync + 'static,
     MW: MatchWriter + Send + Sync + 'static,
     SSW: SetWriter + Send + Sync + 'static,
+    SR: SettingsReader + Send + Sync + 'static,
 > {
     list_state: ListState,
     team: TeamEntry,
@@ -53,6 +55,7 @@ pub struct TeamDetailsScreen<
     match_reader: Arc<MR>,
     match_writer: Arc<MW>,
     set_writer: Arc<SSW>,
+    settings_reader: Arc<SR>,
 }
 
 #[async_trait]
@@ -62,7 +65,8 @@ impl<
         MR: MatchReader + Send + Sync + 'static,
         MW: MatchWriter + Send + Sync + 'static,
         SSW: SetWriter + Send + Sync + 'static,
-    > ScreenAsync for TeamDetailsScreen<TR, TW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync + 'static,
+    > ScreenAsync for TeamDetailsScreen<TR, TW, MR, MW, SSW, SR>
 {
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         match (
@@ -120,6 +124,7 @@ impl<
                         self.match_reader.clone(),
                         self.match_writer.clone(),
                         self.set_writer.clone(),
+                        self.settings_reader.clone(),
                     ))),
                 }
             }
@@ -206,7 +211,8 @@ impl<
         MR: MatchReader + Send + Sync,
         MW: MatchWriter + Send + Sync,
         SSW: SetWriter + Send + Sync,
-    > Renderable for TeamDetailsScreen<TR, TW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync,
+    > Renderable for TeamDetailsScreen<TR, TW, MR, MW, SSW, SR>
 {
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         self.notifier.render(f, footer_right);
@@ -260,7 +266,8 @@ impl<
         MR: MatchReader + Send + Sync,
         MW: MatchWriter + Send + Sync,
         SSW: SetWriter + Send + Sync,
-    > TeamDetailsScreen<TR, TW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync,
+    > TeamDetailsScreen<TR, TW, MR, MW, SSW, SR>
 {
     pub fn new(
         team: &TeamEntry,
@@ -270,6 +277,7 @@ impl<
         match_reader: Arc<MR>,
         match_writer: Arc<MW>,
         set_writer: Arc<SSW>,
+        settings_reader: Arc<SR>,
     ) -> Self {
         let header = TeamHeader::default();
         TeamDetailsScreen {
@@ -283,6 +291,7 @@ impl<
             match_reader,
             match_writer,
             set_writer,
+            settings_reader,
             notifier: NotifyDialogue::new(),
         }
     }

--- a/src/screens/team_list_screen.rs
+++ b/src/screens/team_list_screen.rs
@@ -4,7 +4,8 @@ use crate::{
     localization::current_labels,
     providers::{
         match_reader::MatchReader, match_writer::MatchWriter, set_writer::SetWriter,
-        settings_writer::SettingsWriter, team_reader::TeamReader, team_writer::TeamWriter,
+        settings_reader::SettingsReader, settings_writer::SettingsWriter, team_reader::TeamReader,
+        team_writer::TeamWriter,
     },
     screens::{
         components::{navigation_footer::NavigationFooter, notify_banner::NotifyBanner},
@@ -35,6 +36,7 @@ pub struct TeamListScreen<
     MR: MatchReader + Send + Sync,
     MW: MatchWriter + Send + Sync,
     SSW: SetWriter + Send + Sync,
+    SR: SettingsReader + Send + Sync,
 > {
     list_state: ListState,
     teams: Vec<TeamEntry>,
@@ -48,6 +50,7 @@ pub struct TeamListScreen<
     match_reader: Arc<MR>,
     match_writer: Arc<MW>,
     set_writer: Arc<SSW>,
+    settings_reader: Arc<SR>,
 }
 
 #[async_trait]
@@ -58,7 +61,8 @@ impl<
         MR: MatchReader + Send + Sync + 'static,
         MW: MatchWriter + Send + Sync + 'static,
         SSW: SetWriter + Send + Sync + 'static,
-    > ScreenAsync for TeamListScreen<TR, TW, SW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync + 'static,
+    > ScreenAsync for TeamListScreen<TR, TW, SW, MR, MW, SSW, SR>
 {
     async fn refresh_data(&mut self) {
         match self.team_reader.read_all().await {
@@ -107,6 +111,7 @@ impl<
                     self.match_reader.clone(),
                     self.match_writer.clone(),
                     self.set_writer.clone(),
+                    self.settings_reader.clone(),
                 ))),
             },
             (KeyCode::Esc, _) => AppAction::Back(true, Some(1)),
@@ -144,7 +149,8 @@ impl<
         MR: MatchReader + Send + Sync + 'static,
         MW: MatchWriter + Send + Sync + 'static,
         SSW: SetWriter + Send + Sync + 'static,
-    > Renderable for TeamListScreen<TR, TW, SW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync + 'static,
+    > Renderable for TeamListScreen<TR, TW, SW, MR, MW, SSW, SR>
 {
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         self.notify_message.render(f, footer_right);
@@ -182,7 +188,8 @@ impl<
         MR: MatchReader + Send + Sync,
         MW: MatchWriter + Send + Sync,
         SSW: SetWriter + Send + Sync,
-    > TeamListScreen<TR, TW, SW, MR, MW, SSW>
+        SR: SettingsReader + Send + Sync,
+    > TeamListScreen<TR, TW, SW, MR, MW, SSW, SR>
 {
     pub fn new(
         settings: Settings,
@@ -194,6 +201,7 @@ impl<
         match_reader: Arc<MR>,
         match_writer: Arc<MW>,
         set_writer: Arc<SSW>,
+        settings_reader: Arc<SR>,
     ) -> Self {
         TeamListScreen {
             teams,
@@ -208,6 +216,7 @@ impl<
             match_reader,
             match_writer,
             set_writer,
+            settings_reader,
         }
     }
 

--- a/src/shapes/enums.rs
+++ b/src/shapes/enums.rs
@@ -778,6 +778,16 @@ impl FromStr for LanguageEnum {
     }
 }
 
+impl FriendlyName for LanguageEnum {
+    fn friendly_name(&self, _: &Labels) -> &'static str {
+        use LanguageEnum::*;
+        match self {
+            En => "english",
+            It => "italiano",
+        }
+    }
+}
+
 /// Global classification system that categorizes teams by their performance model, competitive context and level of professionalism.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TeamClassificationEnum {

--- a/src/shapes/settings.rs
+++ b/src/shapes/settings.rs
@@ -5,12 +5,19 @@ use std::str::FromStr;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub language: LanguageEnum,
+    #[serde(default = "default_analytics_enabled")]
+    pub analytics_enabled: bool,
+}
+
+fn default_analytics_enabled() -> bool {
+    true
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
             language: LanguageEnum::from_str(DEFAULT_LANGUAGE).unwrap_or(LanguageEnum::En),
+            analytics_enabled: true,
         }
     }
 }


### PR DESCRIPTION
This PR introduces an opt-in anonymous analytics system that automatically collects and uploads completed volleyball match data for analysis. Users can control this feature through a new settings toggle, ensuring full transparency and control over data sharing.

## analytics upload pipeline

* background worker that processes upload queue every 30 seconds
* asynchronous, non-blocking upload system using tokio runtime
* automatic retry mechanism for failed uploads (indefinite with backoff)
* thread-safe queue management with mutex-based synchronization

## data collection

* collects match data only when analytics are enabled AND match is completed
* creates ZIP archives containing:
    * match metadata (date, teams, classification, etc.)
    * set descriptors and event logs for each set
* generates deterministic UUID v5 identifiers from `team_id` + `match_id`
* uploads to signed URLs obtained from backend service

## user controls

* new checkbox in **settings** screen to enable/disable analytics
* analytics enabled by default for new installations
* backward compatible: defaults to true for existing users without the setting