### PR TITLE
Remember last export directory

### DIFF
--- a/src/localization.rs
+++ b/src/localization.rs
@@ -217,6 +217,7 @@ pub struct Labels {
     pub invalid_email_address: &'static str,
     pub y: &'static char,
     pub enable_send_analytics: &'static str,
+    pub file_already_exists: &'static str,
 }
 
 const EN: Labels = Labels {
@@ -433,6 +434,7 @@ const EN: Labels = Labels {
     invalid_email_address: "invalid email address",
     y: &'y',
     enable_send_analytics: "enable sending anonymous analytics data",
+    file_already_exists: "file already exists",
 };
 
 const IT: Labels = Labels {
@@ -649,6 +651,7 @@ const IT: Labels = Labels {
     invalid_email_address: "indirizzo email non valido",
     y: &'s',
     enable_send_analytics: "abilita l'invio di dati analitici anonimi",
+    file_already_exists: "il file esiste già",
 };
 
 static DICTIONARY: Lazy<HashMap<LanguageEnum, &'static Labels>> = Lazy::new(|| {

--- a/src/providers/settings_writer.rs
+++ b/src/providers/settings_writer.rs
@@ -1,14 +1,7 @@
-use crate::{
-    errors::AppError,
-    shapes::{enums::LanguageEnum, settings::Settings},
-};
+use crate::{errors::AppError, shapes::settings::Settings};
 use async_trait::async_trait;
 
 #[async_trait]
 pub trait SettingsWriter {
-    async fn save(
-        &self,
-        language: LanguageEnum,
-        analytics_enabled: bool,
-    ) -> Result<Settings, AppError>;
+    async fn save(&self, settings: Settings) -> Result<Settings, AppError>;
 }

--- a/src/screens/settings_screen.rs
+++ b/src/screens/settings_screen.rs
@@ -30,6 +30,7 @@ pub struct SettingsScreen<SW: SettingsWriter + Send + Sync> {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     settings_writer: Arc<SW>,
+    settings: Settings,
 }
 
 impl<SW: SettingsWriter + Send + Sync> Renderable for SettingsScreen<SW> {
@@ -110,6 +111,7 @@ impl<SW: SettingsWriter + Send + Sync> SettingsScreen<SW> {
                 ("Q".to_string(), current_labels().quit.to_string()),
             ],
             settings_writer,
+            settings,
         }
     }
 
@@ -119,7 +121,12 @@ impl<SW: SettingsWriter + Send + Sync> SettingsScreen<SW> {
             self.analytics_enabled.get_selected_value(),
         ) {
             (Some(language), analytics_enabled) => {
-                match self.settings_writer.save(language, analytics_enabled).await {
+                let settings = Settings {
+                    language,
+                    analytics_enabled,
+                    last_used_dir: self.settings.last_used_dir.clone(),
+                };
+                match self.settings_writer.save(settings).await {
                     Ok(_) => {
                         set_language(language);
                         self.notify_message

--- a/src/screens/team_list_screen.rs
+++ b/src/screens/team_list_screen.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use crossterm::event::{KeyCode, KeyEvent};
-use dirs::home_dir;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -112,27 +111,33 @@ impl<
                     self.match_writer.clone(),
                     self.set_writer.clone(),
                     self.settings_reader.clone(),
+                    self.settings_writer.clone(),
                 ))),
             },
             (KeyCode::Esc, _) => AppAction::Back(true, Some(1)),
             (KeyCode::Char('n'), _) => {
                 AppAction::SwitchScreen(Box::new(EditTeamScreen::new(self.team_writer.clone())))
             }
-            (KeyCode::Char('i'), _) => match home_dir() {
-                Some(path) => AppAction::SwitchScreen(Box::new(FileSystemScreen::new(
-                    path,
-                    current_labels().import_team,
-                    ImportTeamAction::new(self.team_reader.clone(), self.team_writer.clone()),
-                ))),
-                None => {
-                    self.notify_message.set_error(
-                        current_labels()
-                            .could_not_recognize_home_directory
-                            .to_string(),
-                    );
-                    AppAction::None
+            (KeyCode::Char('i'), _) => {
+                let default_path = self.settings.get_default_path();
+                match default_path {
+                    Some(path) => AppAction::SwitchScreen(Box::new(FileSystemScreen::new(
+                        path,
+                        current_labels().import_team,
+                        ImportTeamAction::new(self.team_reader.clone(), self.team_writer.clone()),
+                        self.settings_reader.clone(),
+                        self.settings_writer.clone(),
+                    ))),
+                    None => {
+                        self.notify_message.set_error(
+                            current_labels()
+                                .could_not_recognize_home_directory
+                                .to_string(),
+                        );
+                        AppAction::None
+                    }
                 }
-            },
+            }
             (KeyCode::Char('s'), _) => AppAction::SwitchScreen(Box::new(SettingsScreen::new(
                 self.settings.clone(),
                 self.settings_writer.clone(),

--- a/src/shapes/settings.rs
+++ b/src/shapes/settings.rs
@@ -1,16 +1,23 @@
 use crate::{constants::DEFAULT_LANGUAGE, shapes::enums::LanguageEnum};
+use dirs::home_dir;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub language: LanguageEnum,
     #[serde(default = "default_analytics_enabled")]
     pub analytics_enabled: bool,
+    #[serde(default = "default_last_used_dir")]
+    pub last_used_dir: Option<PathBuf>,
 }
 
 fn default_analytics_enabled() -> bool {
     true
+}
+
+fn default_last_used_dir() -> Option<PathBuf> {
+    None
 }
 
 impl Default for Settings {
@@ -18,6 +25,13 @@ impl Default for Settings {
         Self {
             language: LanguageEnum::from_str(DEFAULT_LANGUAGE).unwrap_or(LanguageEnum::En),
             analytics_enabled: true,
+            last_used_dir: None,
         }
+    }
+}
+
+impl Settings {
+    pub fn get_default_path(&self) -> Option<PathBuf> {
+        self.last_used_dir.clone().or_else(home_dir)
     }
 }


### PR DESCRIPTION

Improves the export experience by remembering the last directory used and preventing accidental file overwrites.

* remembers last import/export directory across sessions
* shows full exported file path in success message
* prevents overwriting existing files
* analytics worker now starts only when enabled

closes naighes/scoutforall#32