### PR TITLE
Scouting keybinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,18 +4405,18 @@ checksum = "7d246cf599d5fae3c8d56e04b20eb519adb89a8af8d0b0fbcded369aa3647d65"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -5487,9 +5487,9 @@ checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zopfli"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete_nushell"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811159f339691baacdf7d534df2946b9d217014081099e23d31d887d99521e70"
+checksum = "685bc86fd34b7467e0532a4f8435ab107960d69a243785ef0275e571b35b641a"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1485,7 +1485,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2555,9 +2555,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppmd-rust"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
+checksum = "d558c559f0450f16f2a27a1f017ef38468c1090c9ce63c8e51366232d53717b4"
 
 [[package]]
 name = "ppv-lite86"
@@ -2932,7 +2932,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -3870,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4750,14 +4750,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",

--- a/src/screens/add_match_screen.rs
+++ b/src/screens/add_match_screen.rs
@@ -37,7 +37,7 @@ pub struct AddMatchScreen<MW: MatchWriter + Send + Sync, SSW: SetWriter + Send +
     footer_entries: Vec<(String, String)>,
     match_writer: Arc<MW>,
     set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'static> Renderable

--- a/src/screens/add_match_screen.rs
+++ b/src/screens/add_match_screen.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::{
     localization::current_labels,
-    providers::{match_writer::MatchWriter, set_writer::SetWriter},
+    providers::{
+        match_writer::MatchWriter, set_writer::SetWriter, settings_reader::SettingsReader,
+        settings_writer::SettingsWriter,
+    },
     screens::{
         components::{
             checkbox::CheckBox, date_picker::DatePicker, navigation_footer::NavigationFooter,
@@ -12,7 +15,8 @@ use crate::{
         start_set_screen::StartSetScreen,
     },
     shapes::{
-        enums::ScreenActionEnum, keybinding::ScreenKeyBindings, settings::Settings, team::TeamEntry,
+        enums::ScreenActionEnum, keybinding::ActionsKeyBindings, settings::Settings,
+        team::TeamEntry,
     },
 };
 use async_trait::async_trait;
@@ -24,7 +28,16 @@ use ratatui::{
 };
 
 #[derive(Debug)]
-pub struct AddMatchScreen<MW: MatchWriter + Send + Sync, SSW: SetWriter + Send + Sync> {
+pub struct AddMatchScreen<
+    MW: MatchWriter + Send + Sync,
+    SSW: SetWriter + Send + Sync,
+    SR: SettingsReader + Send + Sync + 'static,
+    SW: SettingsWriter + Send + Sync + 'static,
+> {
+    settings_reader: Arc<SR>,
+    settings_writer: Arc<SW>,
+    match_writer: Arc<MW>,
+    set_writer: Arc<SSW>,
     settings: Settings,
     team: TeamEntry,
     opponent: TextBox, // field 0
@@ -35,13 +48,15 @@ pub struct AddMatchScreen<MW: MatchWriter + Send + Sync, SSW: SetWriter + Send +
     header: TeamHeader,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
-    match_writer: Arc<MW>,
-    set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
-impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'static> Renderable
-    for AddMatchScreen<MW, SSW>
+impl<
+        MW: MatchWriter + Send + Sync + 'static,
+        SSW: SetWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+    > Renderable for AddMatchScreen<MW, SSW, SR, SW>
 {
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         let container = Layout::default()
@@ -71,8 +86,12 @@ impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'st
 }
 
 #[async_trait]
-impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'static> ScreenAsync
-    for AddMatchScreen<MW, SSW>
+impl<
+        MW: MatchWriter + Send + Sync + 'static,
+        SSW: SetWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+    > ScreenAsync for AddMatchScreen<MW, SSW, SR, SW>
 {
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         if let Some(key_combination) = self.screen_key_bindings.transform(key) {
@@ -101,10 +120,16 @@ impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'st
     async fn refresh_data(&mut self) {}
 }
 
-impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'static>
-    AddMatchScreen<MW, SSW>
+impl<
+        MW: MatchWriter + Send + Sync + 'static,
+        SSW: SetWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+    > AddMatchScreen<MW, SSW, SR, SW>
 {
     pub fn new(
+        settings_reader: Arc<SR>,
+        settings_writer: Arc<SW>,
         settings: Settings,
         team: TeamEntry,
         match_writer: Arc<MW>,
@@ -124,6 +149,8 @@ impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'st
         let footer_entries = get_keybinding_actions(kb, screen_actions);
         let screen_key_bindings = kb.slice(Sba::keys(screen_actions));
         AddMatchScreen {
+            settings_reader,
+            settings_writer,
             settings,
             team,
             opponent,
@@ -164,6 +191,8 @@ impl<MW: MatchWriter + Send + Sync + 'static, SSW: SetWriter + Send + Sync + 'st
                     .await
                 {
                     Ok(m) => AppAction::SwitchScreen(Box::new(StartSetScreen::new(
+                        self.settings_reader.clone(),
+                        self.settings_writer.clone(),
                         self.settings.clone(),
                         m,
                         1,

--- a/src/screens/edit_player_screen.rs
+++ b/src/screens/edit_player_screen.rs
@@ -43,7 +43,7 @@ pub struct EditPlayerScreen<TW: TeamWriter + Send + Sync> {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     team_writer: Arc<TW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 impl<TW: TeamWriter + Send + Sync> Renderable for EditPlayerScreen<TW> {

--- a/src/screens/edit_player_screen.rs
+++ b/src/screens/edit_player_screen.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     shapes::{
         enums::{RoleEnum, ScreenActionEnum},
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         player::PlayerEntry,
         settings::Settings,
         team::TeamEntry,
@@ -43,7 +43,7 @@ pub struct EditPlayerScreen<TW: TeamWriter + Send + Sync> {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     team_writer: Arc<TW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 impl<TW: TeamWriter + Send + Sync> Renderable for EditPlayerScreen<TW> {

--- a/src/screens/edit_team_screen.rs
+++ b/src/screens/edit_team_screen.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     shapes::{
         enums::{FriendlyName, GenderEnum, ScreenActionEnum, TeamClassificationEnum},
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         settings::Settings,
         team::TeamEntry,
     },
@@ -39,7 +39,7 @@ pub struct EditTeamScreen<TW: TeamWriter + Send + Sync> {
     back: bool,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
     team_writer: Arc<TW>,
 }
 

--- a/src/screens/edit_team_screen.rs
+++ b/src/screens/edit_team_screen.rs
@@ -39,7 +39,7 @@ pub struct EditTeamScreen<TW: TeamWriter + Send + Sync> {
     back: bool,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
     team_writer: Arc<TW>,
 }
 

--- a/src/screens/file_system_screen.rs
+++ b/src/screens/file_system_screen.rs
@@ -49,7 +49,7 @@ pub struct FileSystemScreen<
     back: bool,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
     footer: NavigationFooter,
 }
 
@@ -177,7 +177,7 @@ where
         f.render_widget(paragraph, chunks[1]);
     }
 
-    fn get_footer_actions(&self) -> Vec<Sba> {
+    fn get_footer_actions(&self) -> Vec<Sba<ScreenActionEnum>> {
         let actions = &mut vec![];
 
         if !self.entries.is_empty() {

--- a/src/screens/file_system_screen.rs
+++ b/src/screens/file_system_screen.rs
@@ -6,7 +6,7 @@ use crate::{
         components::{navigation_footer::NavigationFooter, notify_banner::NotifyBanner},
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
-    shapes::{enums::ScreenActionEnum, keybinding::ScreenKeyBindings, settings::Settings},
+    shapes::{enums::ScreenActionEnum, keybinding::ActionsKeyBindings, settings::Settings},
 };
 use async_trait::async_trait;
 use ratatui::{
@@ -49,7 +49,7 @@ pub struct FileSystemScreen<
     back: bool,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
     footer: NavigationFooter,
 }
 
@@ -79,7 +79,7 @@ where
             action,
             back: false,
             footer: NavigationFooter::new(),
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
             settings_reader,
             settings_writer,
         }

--- a/src/screens/keybindings_action_add_screen.rs
+++ b/src/screens/keybindings_action_add_screen.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 use crate::{
     localization::current_labels,
@@ -11,7 +11,7 @@ use crate::{
     },
     shapes::{
         enums::{ScreenActionEnum, WithDesc},
-        keybinding::ScreenKeyBindings,
+        keybinding::{ActionsKeyBindings, KeyBindings},
         settings::{current_settings, set_settings, Settings},
     },
 };
@@ -24,19 +24,28 @@ use ratatui::{
 };
 
 #[derive(Debug)]
-pub struct AddKeyBindings<SW: SettingsWriter + Send + Sync> {
+pub struct AddKeyBindingScreen<
+    SW: SettingsWriter + Send + Sync,
+    T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+> {
     settings: Settings,
-    action: ScreenActionEnum,
+    action: T,
     shortcut: TextBox,
     notify_message: NotifyBanner,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
     fmt: KeyCombinationFormat,
+    keybindings: KeyBindings<T>,
+    fn_settings_updater: fn(&Settings, &KeyBindings<T>) -> Settings,
 }
 
-impl<SW: SettingsWriter + Send + Sync> Renderable for AddKeyBindings<SW> {
+impl<
+        SW: SettingsWriter + Send + Sync,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > Renderable for AddKeyBindingScreen<SW, T>
+{
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         let container = Layout::default()
             .direction(Direction::Vertical)
@@ -60,7 +69,11 @@ impl<SW: SettingsWriter + Send + Sync> Renderable for AddKeyBindings<SW> {
 }
 
 #[async_trait]
-impl<SW: SettingsWriter + Send + Sync> ScreenAsync for AddKeyBindings<SW> {
+impl<
+        SW: SettingsWriter + Send + Sync,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > ScreenAsync for AddKeyBindingScreen<SW, T>
+{
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         if let Some(key_combination) = self.screen_key_bindings.transform(key) {
             match (
@@ -86,8 +99,17 @@ impl<SW: SettingsWriter + Send + Sync> ScreenAsync for AddKeyBindings<SW> {
     async fn refresh_data(&mut self) {}
 }
 
-impl<SW: SettingsWriter + Send + Sync> AddKeyBindings<SW> {
-    pub fn new(action: ScreenActionEnum, settings_writer: Arc<SW>) -> Self {
+impl<
+        SW: SettingsWriter + Send + Sync,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > AddKeyBindingScreen<SW, T>
+{
+    pub fn new(
+        action: T,
+        settings_writer: Arc<SW>,
+        keybindings: KeyBindings<T>,
+        fn_settings_updater: fn(&Settings, &KeyBindings<T>) -> Settings,
+    ) -> Self {
         let shortcut = TextBox::new("shortcut".to_owned(), true, None);
         let screen_actions = &[
             Sba::Simple(ScreenActionEnum::Next),
@@ -99,7 +121,7 @@ impl<SW: SettingsWriter + Send + Sync> AddKeyBindings<SW> {
         let kb = settings.keybindings.clone();
         let footer_entries = get_keybinding_actions(&kb, screen_actions);
         let screen_key_bindings = kb.slice(Sba::keys(screen_actions));
-        AddKeyBindings {
+        AddKeyBindingScreen {
             settings,
             action,
             shortcut,
@@ -109,6 +131,8 @@ impl<SW: SettingsWriter + Send + Sync> AddKeyBindings<SW> {
             screen_key_bindings,
             settings_writer,
             fmt: KeyCombinationFormat::default(),
+            keybindings,
+            fn_settings_updater,
         }
     }
 
@@ -130,10 +154,9 @@ impl<SW: SettingsWriter + Send + Sync> AddKeyBindings<SW> {
                 let kc = crokey::parse(&sc);
                 match kc {
                     Ok(kc) => {
-                        let mut settings = self.settings.clone();
-                        let mut keybindings = settings.keybindings.clone();
+                        let mut keybindings = self.keybindings.clone();
                         if keybindings.set(self.action, kc) {
-                            settings.keybindings = keybindings.clone();
+                            let settings = (self.fn_settings_updater)(&self.settings, &keybindings);
                             match self.settings_writer.save(settings).await {
                                 Ok(saved_settings) => {
                                     set_settings(saved_settings.clone());

--- a/src/screens/keybindings_action_add_screen.rs
+++ b/src/screens/keybindings_action_add_screen.rs
@@ -10,7 +10,7 @@ use crate::{
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::ScreenActionEnum,
+        enums::{ScreenActionEnum, WithDesc},
         keybinding::ScreenKeyBindings,
         settings::{current_settings, set_settings, Settings},
     },
@@ -32,7 +32,7 @@ pub struct AddKeyBindings<SW: SettingsWriter + Send + Sync> {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
     fmt: KeyCombinationFormat,
 }
 

--- a/src/screens/keybindings_action_screen.rs
+++ b/src/screens/keybindings_action_screen.rs
@@ -9,7 +9,7 @@ use crate::{
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::ScreenActionEnum,
+        enums::{ScreenActionEnum, WithDesc},
         keybinding::ScreenKeyBindings,
         settings::{set_settings, Settings},
     },
@@ -40,7 +40,7 @@ pub struct KeyBindingActionScreen<
     action: ScreenActionEnum,
     format: KeyCombinationFormat,
     key_combinations: HashSet<KeyCombination>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
     footer_entries: Vec<(String, String)>,
 }
 
@@ -189,7 +189,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
         }
     }
 
-    fn get_screen_actions(length: &usize) -> Vec<Sba> {
+    fn get_screen_actions(length: &usize) -> Vec<Sba<ScreenActionEnum>> {
         if *length > 1 {
             vec![
                 Sba::Simple(ScreenActionEnum::Previous),

--- a/src/screens/keybindings_action_screen.rs
+++ b/src/screens/keybindings_action_screen.rs
@@ -5,12 +5,12 @@ use crate::{
     providers::{settings_reader::SettingsReader, settings_writer::SettingsWriter},
     screens::{
         components::{navigation_footer::NavigationFooter, notify_dialogue::NotifyDialogue},
-        keybindings_action_add_screen::AddKeyBindings,
+        keybindings_action_add_screen::AddKeyBindingScreen,
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
         enums::{ScreenActionEnum, WithDesc},
-        keybinding::ScreenKeyBindings,
+        keybinding::{ActionsKeyBindings, KeyBindings},
         settings::{set_settings, Settings},
     },
 };
@@ -25,11 +25,13 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame,
 };
+use std::hash::Hash;
 
 #[derive(Debug)]
-pub struct KeyBindingActionScreen<
+pub struct KeyBindingScreen<
     SW: SettingsWriter + Send + Sync,
     SR: SettingsReader + Send + Sync,
+    T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
 > {
     settings: Settings,
     list_state: ListState,
@@ -37,21 +39,28 @@ pub struct KeyBindingActionScreen<
     footer: NavigationFooter,
     settings_writer: Arc<SW>,
     settings_reader: Arc<SR>,
-    action: ScreenActionEnum,
+    keybindings: KeyBindings<T>,
+    action: T,
     format: KeyCombinationFormat,
     key_combinations: HashSet<KeyCombination>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
     footer_entries: Vec<(String, String)>,
+    fn_kb_retriever: fn(s: &Settings) -> KeyBindings<T>,
+    fn_settings_updater: fn(s: &Settings, &KeyBindings<T>) -> Settings,
 }
 
 #[async_trait]
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    ScreenAsync for KeyBindingActionScreen<SW, SR>
+impl<
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > ScreenAsync for KeyBindingScreen<SW, SR, T>
 {
     async fn refresh_data(&mut self) {
         if let Ok(settings) = &self.settings_reader.read().await {
             self.settings = settings.to_owned();
-            if let Some(key_combination) = settings.keybindings.reverse_map().get(&self.action) {
+            self.keybindings = (self.fn_kb_retriever)(&self.settings);
+            if let Some(key_combination) = self.keybindings.reverse_map().get(&self.action) {
                 let kb = &settings.keybindings.clone();
                 self.key_combinations = key_combination.clone();
                 let length = self.key_combinations.len();
@@ -108,9 +117,14 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
                     AppAction::None
                 }
                 (Some(ScreenActionEnum::Back), _, _, _) => AppAction::Back(true, Some(1)),
-                (Some(ScreenActionEnum::New), _, _, _) => AppAction::SwitchScreen(Box::new(
-                    AddKeyBindings::new(self.action, self.settings_writer.clone()),
-                )),
+                (Some(ScreenActionEnum::New), _, _, _) => {
+                    AppAction::SwitchScreen(Box::new(AddKeyBindingScreen::new(
+                        self.action,
+                        self.settings_writer.clone(),
+                        self.keybindings.clone(),
+                        self.fn_settings_updater,
+                    )))
+                }
                 (Some(ScreenActionEnum::Delete), _, _, _) => {
                     match self.list_state.selected().map(|selected: usize| {
                         let u = self.key_combinations.iter().nth(selected).cloned();
@@ -139,8 +153,11 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     }
 }
 
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    Renderable for KeyBindingActionScreen<SW, SR>
+impl<
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > Renderable for KeyBindingScreen<SW, SR, T>
 {
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         self.notifier.render(f, footer_right);
@@ -157,16 +174,22 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     }
 }
 
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    KeyBindingActionScreen<SW, SR>
+impl<
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+        T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T> + 'static,
+    > KeyBindingScreen<SW, SR, T>
 {
     pub fn new(
         settings: Settings,
-        action: ScreenActionEnum,
+        action: T,
         key_combinations: HashSet<KeyCombination>,
         format: KeyCombinationFormat,
         settings_writer: Arc<SW>,
         settings_reader: Arc<SR>,
+        keybindings: KeyBindings<T>,
+        fn_kb_retriever: fn(s: &Settings) -> KeyBindings<T>,
+        fn_settings_updater: fn(s: &Settings, &KeyBindings<T>) -> Settings,
     ) -> Self {
         let length = key_combinations.len();
         let screen_actions = &Self::get_screen_actions(&length);
@@ -174,7 +197,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
         let footer_entries = get_keybinding_actions(kb, screen_actions);
         let screen_key_bindings = settings.keybindings.slice(Sba::keys(screen_actions));
 
-        KeyBindingActionScreen {
+        KeyBindingScreen {
             settings,
             action,
             key_combinations,
@@ -186,6 +209,9 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
             settings_reader,
             footer_entries,
             screen_key_bindings,
+            keybindings,
+            fn_kb_retriever,
+            fn_settings_updater,
         }
     }
 
@@ -197,13 +223,11 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
                 Sba::Simple(ScreenActionEnum::New),
                 Sba::Simple(ScreenActionEnum::Delete),
                 Sba::Simple(ScreenActionEnum::Back),
-                Sba::Simple(ScreenActionEnum::Quit),
             ]
         } else {
             vec![
                 Sba::Simple(ScreenActionEnum::New),
                 Sba::Simple(ScreenActionEnum::Back),
-                Sba::Simple(ScreenActionEnum::Quit),
             ]
         }
     }
@@ -243,19 +267,14 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     }
     async fn remove(
         &mut self,
-        action: &mut ScreenActionEnum,
+        action: &mut T,
         key_combination: KeyCombination,
         settings_writer: Arc<SW>,
     ) -> AppAction {
-        let keybindings = &mut self.settings.keybindings;
+        let keybindings = &mut (self.fn_kb_retriever)(&self.settings);
 
         if keybindings.remove(*action, key_combination) {
-            let settings = Settings {
-                language: self.settings.language,
-                analytics_enabled: self.settings.analytics_enabled,
-                keybindings: keybindings.clone(),
-                last_used_dir: self.settings.last_used_dir.to_owned(),
-            };
+            let settings = (self.fn_settings_updater)(&self.settings, keybindings);
             match settings_writer.save(settings).await {
                 Ok(saved_settings) => {
                     set_settings(saved_settings.clone());

--- a/src/screens/keybindings_screen.rs
+++ b/src/screens/keybindings_screen.rs
@@ -54,13 +54,14 @@ where
     T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T>,
 {
     fn get_selected_item(&self, selected: usize) -> Option<T>;
-    fn obtain_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)>;
-    fn set_items(&mut self, settings: &Settings);
+    fn get_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)>;
+    fn apply_settings(&mut self, settings: &Settings);
     fn reset_settings(&mut self) -> Settings;
     fn get_keybindings(&mut self) -> fn(&Settings) -> KeyBindings<T>;
     fn merge_keybindings_into_settings(&mut self) -> fn(&Settings, &KeyBindings<T>) -> Settings;
     fn current_keybindings(&self) -> &KeyBindings<T>;
-    fn derive_key_combinations(&self, action: &T) -> HashSet<KeyCombination>;
+    fn key_combinations_for(&self, action: &T) -> HashSet<KeyCombination>;
+    fn get_settings(&self) -> &Settings;
 }
 
 impl KeyBindingsScreen<EventTypeEnum> {
@@ -114,7 +115,7 @@ impl KeyBindingsScreen<ScreenActionEnum> {
 impl<T: Hash + Eq + WithDesc<T> + Send + Sync + Copy + Clone + 'static> ScreenKeyBindingTrait<T>
     for KeyBindingsScreen<T>
 {
-    fn obtain_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)> {
+    fn get_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)> {
         self.all_values
             .iter()
             .map(|r| {
@@ -160,13 +161,17 @@ impl<T: Hash + Eq + WithDesc<T> + Send + Sync + Copy + Clone + 'static> ScreenKe
         self.all_values.get(selected).cloned()
     }
 
-    fn derive_key_combinations(&self, action: &T) -> HashSet<KeyCombination> {
+    fn key_combinations_for(&self, action: &T) -> HashSet<KeyCombination> {
         (self.derive_key_combinations_from_event)(&self.settings, action)
     }
 
-    fn set_items(&mut self, settings: &Settings) {
+    fn apply_settings(&mut self, settings: &Settings) {
         self.key_bindings = (self.get_keybindings_from_settings)(settings);
         self.settings = settings.to_owned();
+    }
+
+    fn get_settings(&self) -> &Settings {
+        &self.settings
     }
 }
 
@@ -274,8 +279,7 @@ impl<
                         let selected_action = self.data_renderer.get_selected_item(selected);
                         match selected_action {
                             Some(action) => {
-                                let keybindings =
-                                    self.data_renderer.derive_key_combinations(&action);
+                                let keybindings = self.data_renderer.key_combinations_for(&action);
                                 AppAction::SwitchScreen(Box::new(KeyBindingScreen::new(
                                     self.settings.clone(),
                                     action.to_owned(),
@@ -315,8 +319,8 @@ impl<
     async fn refresh_data(&mut self) {
         if let Ok(settings) = &self.settings_reader.read().await {
             self.settings = settings.to_owned();
-            self.data_renderer.set_items(&self.settings);
-            self.items = self.data_renderer.obtain_formatted_items(&self.format);
+            self.data_renderer.apply_settings(&self.settings);
+            self.items = self.data_renderer.get_formatted_items(&self.format);
             let (footer_entries, screen_key_bindings) = get_context_menu(settings);
             self.footer_entries = footer_entries;
             self.screen_key_bindings = screen_key_bindings;
@@ -333,12 +337,8 @@ impl<
 where
     DR: Sync + std::marker::Send,
 {
-    pub fn new(
-        data_renderer: DR,
-        settings: Settings,
-        settings_writer: Arc<SW>,
-        settings_reader: Arc<SR>,
-    ) -> Self {
+    pub fn new(data_renderer: DR, settings_writer: Arc<SW>, settings_reader: Arc<SR>) -> Self {
+        let settings = data_renderer.get_settings().to_owned();
         let language = Select::new(
             current_labels().language.to_owned(),
             LanguageEnum::ALL.to_vec(),
@@ -354,7 +354,7 @@ where
 
         let format = KeyCombinationFormat::default();
 
-        let items = data_renderer.obtain_formatted_items(&format);
+        let items = data_renderer.get_formatted_items(&format);
 
         let scroll_state = ScrollbarState::new((items.len() - 1) * ITEM_HEIGHT);
 

--- a/src/screens/keybindings_screen.rs
+++ b/src/screens/keybindings_screen.rs
@@ -13,7 +13,7 @@ use crate::{
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::{LanguageEnum, ScreenActionEnum},
+        enums::{LanguageEnum, ScreenActionEnum, WithDesc},
         keybinding::{KeyBindings, ScreenKeyBindings},
         settings::{set_settings, Settings},
     },
@@ -45,7 +45,7 @@ pub struct KeybindingScreen<SW: SettingsWriter + Send + Sync, SR: SettingsReader
     settings_writer: Arc<SW>,
     settings_reader: Arc<SR>,
     settings: Settings,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
     format: KeyCombinationFormat,
     scroll_state: ScrollbarState,
     items: Vec<(String, String)>,
@@ -303,7 +303,10 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
         rows
     }
 
-    fn get_items(kc: &KeyBindings, format: &KeyCombinationFormat) -> Vec<(String, String)> {
+    fn get_items(
+        kc: &KeyBindings<ScreenActionEnum>,
+        format: &KeyCombinationFormat,
+    ) -> Vec<(String, String)> {
         ScreenActionEnum::ALL
             .iter()
             .map(|r| {
@@ -370,7 +373,9 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     }
 }
 
-fn get_context_menu(settings: &Settings) -> (Vec<(String, String)>, ScreenKeyBindings) {
+fn get_context_menu(
+    settings: &Settings,
+) -> (Vec<(String, String)>, ScreenKeyBindings<ScreenActionEnum>) {
     let screen_actions = &[
         Sba::Simple(ScreenActionEnum::Previous),
         Sba::Simple(ScreenActionEnum::Next),

--- a/src/screens/keybindings_screen.rs
+++ b/src/screens/keybindings_screen.rs
@@ -1,5 +1,7 @@
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::{hash::Hash, marker::PhantomData, sync::Arc};
 
+use crate::shapes::enums::WithDesc;
 use crate::{
     localization::current_labels,
     providers::{settings_reader::SettingsReader, settings_writer::SettingsWriter},
@@ -8,22 +10,23 @@ use crate::{
             checkbox::CheckBox, navigation_footer::NavigationFooter,
             notify_dialogue::NotifyDialogue, select::Select,
         },
-        keybindings_action_screen::KeyBindingActionScreen,
+        keybindings_action_screen::KeyBindingScreen,
         report_an_issue_screen::ReportAnIssueScreen,
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::{LanguageEnum, ScreenActionEnum, WithDesc},
-        keybinding::{KeyBindings, ScreenKeyBindings},
+        enums::{EventTypeEnum, LanguageEnum, ScreenActionEnum},
+        keybinding::{ActionsKeyBindings, KeyBindings},
         settings::{set_settings, Settings},
     },
 };
 use async_trait::async_trait;
+use crokey::KeyCombination;
 use crokey::{
-    crossterm::{self, event::KeyCode},
+    crossterm::event::{KeyCode, KeyEvent},
     KeyCombinationFormat,
 };
-use crossterm::event::KeyEvent;
+
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -34,7 +37,148 @@ use ratatui::{
 const ITEM_HEIGHT: usize = 2;
 
 #[derive(Debug)]
-pub struct KeybindingScreen<SW: SettingsWriter + Send + Sync, SR: SettingsReader + Send + Sync> {
+pub struct KeyBindingsScreen<T>
+where
+    T: Send + Sync + Hash + Eq + WithDesc<T> + 'static,
+{
+    key_bindings: KeyBindings<T>,
+    all_values: Vec<T>,
+    settings: Settings,
+    get_keybindings_from_settings: fn(s: &Settings) -> KeyBindings<T>,
+    merge_keybindings_into_settings: fn(s: &Settings, &KeyBindings<T>) -> Settings,
+    derive_key_combinations_from_event: fn(s: &Settings, action: &T) -> HashSet<KeyCombination>,
+}
+
+pub trait ScreenKeyBindingTrait<T>
+where
+    T: Clone + Copy + Send + Sync + Eq + Hash + WithDesc<T>,
+{
+    fn get_selected_item(&self, selected: usize) -> Option<T>;
+    fn obtain_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)>;
+    fn set_items(&mut self, settings: &Settings);
+    fn reset_settings(&mut self) -> Settings;
+    fn get_keybindings(&mut self) -> fn(&Settings) -> KeyBindings<T>;
+    fn merge_keybindings_into_settings(&mut self) -> fn(&Settings, &KeyBindings<T>) -> Settings;
+    fn current_keybindings(&self) -> &KeyBindings<T>;
+    fn derive_key_combinations(&self, action: &T) -> HashSet<KeyCombination>;
+}
+
+impl KeyBindingsScreen<EventTypeEnum> {
+    pub fn new(settings: Settings) -> Self {
+        let fn_kb_retriever = |s: &Settings| s.scouting_keybindings.clone();
+        KeyBindingsScreen {
+            key_bindings: (fn_kb_retriever)(&settings),
+            all_values: EventTypeEnum::ALL.to_vec(),
+            settings,
+            get_keybindings_from_settings: fn_kb_retriever,
+            merge_keybindings_into_settings: |s: &Settings, kb: &KeyBindings<EventTypeEnum>| {
+                Settings {
+                    language: s.language,
+                    analytics_enabled: s.analytics_enabled,
+                    keybindings: s.keybindings.clone(),
+                    scouting_keybindings: kb.clone(),
+                    last_used_dir: s.last_used_dir.to_owned(),
+                }
+            },
+            derive_key_combinations_from_event: |s: &Settings, action| {
+                s.scouting_keybindings.keybindings_for(action)
+            },
+        }
+    }
+}
+
+impl KeyBindingsScreen<ScreenActionEnum> {
+    pub fn new(settings: Settings) -> Self {
+        let fn_kb_retriever = |s: &Settings| s.keybindings.clone();
+        KeyBindingsScreen {
+            all_values: ScreenActionEnum::ALL.to_vec(),
+            key_bindings: (fn_kb_retriever)(&settings),
+            settings,
+            get_keybindings_from_settings: fn_kb_retriever,
+            merge_keybindings_into_settings: |s: &Settings, kb: &KeyBindings<ScreenActionEnum>| {
+                Settings {
+                    language: s.language,
+                    analytics_enabled: s.analytics_enabled,
+                    keybindings: kb.clone(),
+                    scouting_keybindings: s.scouting_keybindings.clone(),
+                    last_used_dir: s.last_used_dir.to_owned(),
+                }
+            },
+            derive_key_combinations_from_event: |s: &Settings, action| {
+                s.keybindings.keybindings_for(action)
+            },
+        }
+    }
+}
+
+impl<T: Hash + Eq + WithDesc<T> + Send + Sync + Copy + Clone + 'static> ScreenKeyBindingTrait<T>
+    for KeyBindingsScreen<T>
+{
+    fn obtain_formatted_items(&self, format: &KeyCombinationFormat) -> Vec<(String, String)> {
+        self.all_values
+            .iter()
+            .map(|r| {
+                let s = self
+                    .key_bindings
+                    .reverse_map()
+                    .get(r)
+                    .map(|f| {
+                        f.iter()
+                            .map(|q| format.to_string(*q))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .unwrap_or(current_labels().unassigned.to_string())
+                    .to_string();
+                (r.with_desc().1, s)
+            })
+            .collect::<Vec<_>>()
+    }
+    fn reset_settings(&mut self) -> Settings {
+        Settings {
+            language: self.settings.language,
+            analytics_enabled: self.settings.analytics_enabled,
+            keybindings: KeyBindings::default(),
+            scouting_keybindings: self.settings.scouting_keybindings.clone(),
+            last_used_dir: self.settings.last_used_dir.to_owned(),
+        }
+    }
+
+    fn get_keybindings(&mut self) -> fn(&Settings) -> KeyBindings<T> {
+        self.get_keybindings_from_settings
+    }
+
+    fn merge_keybindings_into_settings(&mut self) -> fn(&Settings, &KeyBindings<T>) -> Settings {
+        self.merge_keybindings_into_settings
+    }
+
+    fn current_keybindings(&self) -> &KeyBindings<T> {
+        &self.key_bindings
+    }
+
+    fn get_selected_item(&self, selected: usize) -> Option<T> {
+        self.all_values.get(selected).cloned()
+    }
+
+    fn derive_key_combinations(&self, action: &T) -> HashSet<KeyCombination> {
+        (self.derive_key_combinations_from_event)(&self.settings, action)
+    }
+
+    fn set_items(&mut self, settings: &Settings) {
+        self.key_bindings = (self.get_keybindings_from_settings)(settings);
+        self.settings = settings.to_owned();
+    }
+}
+
+#[derive(Debug)]
+pub struct KeybindingScreen<
+    T: Clone + Copy + Send + Sync + Hash + Eq + WithDesc<T> + 'static,
+    DR: ScreenKeyBindingTrait<T>,
+    SW: SettingsWriter + Send + Sync,
+    SR: SettingsReader + Send + Sync,
+> where
+    DR: Sync + std::marker::Send,
+{
     language: Select<LanguageEnum>,
     analytics_enabled: CheckBox,
     key_binding_state: TableState,
@@ -45,14 +189,22 @@ pub struct KeybindingScreen<SW: SettingsWriter + Send + Sync, SR: SettingsReader
     settings_writer: Arc<SW>,
     settings_reader: Arc<SR>,
     settings: Settings,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
     format: KeyCombinationFormat,
     scroll_state: ScrollbarState,
     items: Vec<(String, String)>,
+    data_renderer: DR,
+    phantom: PhantomData<T>,
 }
 
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    Renderable for KeybindingScreen<SW, SR>
+impl<
+        T: Clone + Copy + Send + Sync + Hash + Eq + WithDesc<T> + 'static,
+        DR: ScreenKeyBindingTrait<T> + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > Renderable for KeybindingScreen<T, DR, SW, SR>
+where
+    DR: Sync + std::marker::Send,
 {
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         let inner = Layout::default()
@@ -67,7 +219,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
             .split(body);
         self.language.render(f, inner[0]);
         self.analytics_enabled.render(f, inner[1]);
-        self.render_key_bindings_list(f, inner[2]);
+        self.render_key_bindings_table(f, inner[2]);
         self.notifier.render(f, footer_right);
         self.footer
             .render(f, footer_left, self.footer_entries.clone());
@@ -75,8 +227,12 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
 }
 
 #[async_trait]
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    ScreenAsync for KeybindingScreen<SW, SR>
+impl<
+        T: Clone + Copy + Send + Sync + Hash + Eq + WithDesc<T> + 'static,
+        DR: ScreenKeyBindingTrait<T> + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > ScreenAsync for KeybindingScreen<T, DR, SW, SR>
 {
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         if let Some(key_combination) = self.screen_key_bindings.transform(key) {
@@ -115,17 +271,21 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
                 ),
                 (Some(ScreenActionEnum::Edit), _, _, _) => {
                     match self.key_binding_state.selected().map(|selected| {
-                        let action = ScreenActionEnum::ALL.get(selected);
-                        match action {
-                            Some(p) => {
-                                let keybindings = self.settings.keybindings.keybindings_for(p);
-                                AppAction::SwitchScreen(Box::new(KeyBindingActionScreen::new(
+                        let selected_action = self.data_renderer.get_selected_item(selected);
+                        match selected_action {
+                            Some(action) => {
+                                let keybindings =
+                                    self.data_renderer.derive_key_combinations(&action);
+                                AppAction::SwitchScreen(Box::new(KeyBindingScreen::new(
                                     self.settings.clone(),
-                                    p.to_owned(),
+                                    action.to_owned(),
                                     keybindings,
                                     self.format.clone(),
                                     self.settings_writer.clone(),
                                     self.settings_reader.clone(),
+                                    self.data_renderer.current_keybindings().clone(),
+                                    self.data_renderer.get_keybindings(),
+                                    self.data_renderer.merge_keybindings_into_settings(),
                                 )))
                             }
                             None => AppAction::None,
@@ -136,19 +296,13 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
                     }
                 }
                 (Some(ScreenActionEnum::Reset), _, _, _) => {
-                    let settings = Settings {
-                        language: self.settings.language,
-                        analytics_enabled: self.settings.analytics_enabled,
-                        keybindings: KeyBindings::default(),
-                        last_used_dir: self.settings.last_used_dir.to_owned(),
-                    };
+                    let settings = self.data_renderer.reset_settings();
                     self.notifier
                         .set(settings.to_owned())
                         .banner
                         .set_warning(current_labels().reset_to_defaults_confirmation.to_string());
                     AppAction::None
                 }
-                (Some(ScreenActionEnum::Confirm), _, _, _) => self.handle_enter().await,
                 (Some(ScreenActionEnum::Back), _, _, _) => AppAction::Back(true, Some(1)),
                 (Some(ScreenActionEnum::Quit), _, _, _) => AppAction::Quit(Ok(())),
                 _ => AppAction::None,
@@ -161,7 +315,8 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     async fn refresh_data(&mut self) {
         if let Ok(settings) = &self.settings_reader.read().await {
             self.settings = settings.to_owned();
-            self.items = Self::get_items(&settings.keybindings, &self.format);
+            self.data_renderer.set_items(&self.settings);
+            self.items = self.data_renderer.obtain_formatted_items(&self.format);
             let (footer_entries, screen_key_bindings) = get_context_menu(settings);
             self.footer_entries = footer_entries;
             self.screen_key_bindings = screen_key_bindings;
@@ -169,10 +324,21 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
     }
 }
 
-impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Sync + 'static>
-    KeybindingScreen<SW, SR>
+impl<
+        T: Clone + Copy + Send + Sync + Hash + Eq + WithDesc<T> + 'static,
+        DR: ScreenKeyBindingTrait<T> + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > KeybindingScreen<T, DR, SW, SR>
+where
+    DR: Sync + std::marker::Send,
 {
-    pub fn new(settings: Settings, settings_writer: Arc<SW>, settings_reader: Arc<SR>) -> Self {
+    pub fn new(
+        data_renderer: DR,
+        settings: Settings,
+        settings_writer: Arc<SW>,
+        settings_reader: Arc<SR>,
+    ) -> Self {
         let language = Select::new(
             current_labels().language.to_owned(),
             LanguageEnum::ALL.to_vec(),
@@ -188,7 +354,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
 
         let format = KeyCombinationFormat::default();
 
-        let items = Self::get_items(&settings.keybindings, &format);
+        let items = data_renderer.obtain_formatted_items(&format);
 
         let scroll_state = ScrollbarState::new((items.len() - 1) * ITEM_HEIGHT);
 
@@ -209,44 +375,8 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
             format,
             scroll_state,
             items,
-        }
-    }
-
-    async fn handle_enter(&mut self) -> AppAction {
-        match (
-            self.language.get_selected_value(),
-            self.analytics_enabled.get_selected_value(),
-        ) {
-            (Some(language), analytics_enabled) => {
-                let settings = Settings {
-                    language,
-                    analytics_enabled,
-                    keybindings: self.settings.keybindings.clone(),
-                    last_used_dir: self.settings.last_used_dir.clone(),
-                };
-                match self.settings_writer.save(settings).await {
-                    Ok(saved_settings) => {
-                        set_settings(saved_settings);
-                        self.notifier
-                            .banner
-                            .set_info(current_labels().operation_successful.to_string());
-                        self.back = true;
-                        AppAction::None
-                    }
-                    Err(_) => {
-                        self.notifier
-                            .banner
-                            .set_error(current_labels().could_not_save_settings.to_string());
-                        AppAction::None
-                    }
-                }
-            }
-            _ => {
-                self.notifier
-                    .banner
-                    .set_error(current_labels().language_is_required.to_string());
-                AppAction::None
-            }
+            data_renderer,
+            phantom: PhantomData,
         }
     }
 
@@ -303,30 +433,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
         rows
     }
 
-    fn get_items(
-        kc: &KeyBindings<ScreenActionEnum>,
-        format: &KeyCombinationFormat,
-    ) -> Vec<(String, String)> {
-        ScreenActionEnum::ALL
-            .iter()
-            .map(|r| {
-                let s = kc
-                    .reverse_map()
-                    .get(r)
-                    .map(|f| {
-                        f.iter()
-                            .map(|q| format.to_string(*q))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    })
-                    .unwrap_or(current_labels().unassigned.to_string())
-                    .to_string();
-                (r.with_desc().1, s)
-            })
-            .collect::<Vec<_>>()
-    }
-
-    fn render_key_bindings_list(&mut self, f: &mut Frame, area: Rect) {
+    fn render_key_bindings_table(&mut self, f: &mut Frame, area: Rect) {
         // First, get the selected index without borrowing self immutably for too long
         let selected_action = self.key_binding_state.selected().unwrap_or_else(|| {
             self.key_binding_state.select(Some(0));
@@ -375,7 +482,7 @@ impl<SW: SettingsWriter + Send + Sync + 'static, SR: SettingsReader + Send + Syn
 
 fn get_context_menu(
     settings: &Settings,
-) -> (Vec<(String, String)>, ScreenKeyBindings<ScreenActionEnum>) {
+) -> (Vec<(String, String)>, ActionsKeyBindings<ScreenActionEnum>) {
     let screen_actions = &[
         Sba::Simple(ScreenActionEnum::Previous),
         Sba::Simple(ScreenActionEnum::Next),

--- a/src/screens/match_list_screen.rs
+++ b/src/screens/match_list_screen.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     shapes::{
         enums::{ScreenActionEnum, TeamSideEnum},
-        keybinding::{KeyBindings, ScreenKeyBindings},
+        keybinding::{ActionsKeyBindings, KeyBindings},
         r#match::{MatchEntry, MatchStatus},
         set::SetEntry,
         settings::Settings,
@@ -66,7 +66,7 @@ pub struct MatchListScreen<
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 impl<
@@ -168,6 +168,8 @@ impl<
                 (Some(ScreenActionEnum::New), _, _) => {
                     if self.team.players.len() >= 6 {
                         AppAction::SwitchScreen(Box::new(AddMatchScreen::new(
+                            self.settings_reader.clone(),
+                            self.settings_writer.clone(),
                             self.settings.clone(),
                             self.team.clone(),
                             self.match_writer.clone(),
@@ -301,7 +303,7 @@ impl<
             set_writer,
             settings_reader,
             settings_writer,
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
         }
     }
     fn get_selected_match(&self) -> Option<(&MatchEntry, &MatchStatus)> {
@@ -364,6 +366,8 @@ impl<
         last_serving_team: Option<TeamSideEnum>,
     ) -> AppAction {
         AppAction::SwitchScreen(Box::new(StartSetScreen::new(
+            self.settings_reader.clone(),
+            self.settings_writer.clone(),
             self.settings.clone(),
             m.clone(),
             next_set_number,
@@ -381,7 +385,9 @@ impl<
     fn continue_set(&mut self, m: &MatchEntry, last_incomplete_set: SetEntry) -> AppAction {
         match last_incomplete_set.compute_snapshot() {
             Ok((snapshot, available_options)) => {
-                AppAction::SwitchScreen(Box::new(ScoutingScreen::new(
+                let x = ScoutingScreen::new(
+                    self.settings_reader.clone(),
+                    self.settings_writer.clone(),
                     self.settings.clone(),
                     m.clone(),
                     last_incomplete_set,
@@ -389,7 +395,17 @@ impl<
                     available_options,
                     Some(1),
                     self.set_writer.clone(),
-                )))
+                );
+                // let x = ScoutingScreenOrig::new(
+                //     self.settings.clone(),
+                //     m.clone(),
+                //     last_incomplete_set,
+                //     snapshot,
+                //     available_options,
+                //     Some(1),
+                //     self.set_writer.clone(),
+                // );
+                AppAction::SwitchScreen(Box::new(x))
             }
             Err(_) => {
                 self.notify_message

--- a/src/screens/match_list_screen.rs
+++ b/src/screens/match_list_screen.rs
@@ -385,7 +385,7 @@ impl<
     fn continue_set(&mut self, m: &MatchEntry, last_incomplete_set: SetEntry) -> AppAction {
         match last_incomplete_set.compute_snapshot() {
             Ok((snapshot, available_options)) => {
-                let x = ScoutingScreen::new(
+                AppAction::SwitchScreen(Box::new(ScoutingScreen::new(
                     self.settings_reader.clone(),
                     self.settings_writer.clone(),
                     self.settings.clone(),
@@ -395,17 +395,7 @@ impl<
                     available_options,
                     Some(1),
                     self.set_writer.clone(),
-                );
-                // let x = ScoutingScreenOrig::new(
-                //     self.settings.clone(),
-                //     m.clone(),
-                //     last_incomplete_set,
-                //     snapshot,
-                //     available_options,
-                //     Some(1),
-                //     self.set_writer.clone(),
-                // );
-                AppAction::SwitchScreen(Box::new(x))
+                )))
             }
             Err(_) => {
                 self.notify_message

--- a/src/screens/match_list_screen.rs
+++ b/src/screens/match_list_screen.rs
@@ -66,7 +66,7 @@ pub struct MatchListScreen<
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 impl<
@@ -129,7 +129,7 @@ impl<
         }
         self.header.render(f, container[0], Some(&self.team));
         self.notify_message.render(f, footer_right);
-        let kb: &KeyBindings = &self.settings.keybindings;
+        let kb: &KeyBindings<ScreenActionEnum> = &self.settings.keybindings;
         let screen_actions = &self.screen_actions();
         let screen_key_bindings = &kb.slice(Sba::keys(screen_actions));
         let footer_entries = get_keybinding_actions(kb, screen_actions);
@@ -415,7 +415,7 @@ impl<
         AppAction::None
     }
 
-    fn screen_actions(&self) -> Vec<Sba> {
+    fn screen_actions(&self) -> Vec<Sba<ScreenActionEnum>> {
         let mut actions = Vec::new();
         actions.push(Sba::Redacted(ScreenActionEnum::Import, |lbl| -> String {
             lbl.replace("{}", current_labels().match_word)

--- a/src/screens/match_stats_screen.rs
+++ b/src/screens/match_stats_screen.rs
@@ -10,7 +10,7 @@ use crate::{
             ErrorTypeEnum, EvalEnum, EventTypeEnum, FriendlyName, PhaseEnum, RotationEnum,
             ScreenActionEnum, ZoneEnum,
         },
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         player::PlayerEntry,
         r#match::MatchEntry,
         set::SetEntry,
@@ -168,7 +168,7 @@ pub struct MatchStatsScreen {
     sets: Vec<(SetEntry, Snapshot)>,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]

--- a/src/screens/match_stats_screen.rs
+++ b/src/screens/match_stats_screen.rs
@@ -168,7 +168,7 @@ pub struct MatchStatsScreen {
     sets: Vec<(SetEntry, Snapshot)>,
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]

--- a/src/screens/report_an_issue_screen.rs
+++ b/src/screens/report_an_issue_screen.rs
@@ -48,7 +48,7 @@ pub struct ReportAnIssueScreen {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     combiner: Combiner,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 impl Renderable for ReportAnIssueScreen {

--- a/src/screens/report_an_issue_screen.rs
+++ b/src/screens/report_an_issue_screen.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
-    shapes::{enums::ScreenActionEnum, keybinding::ScreenKeyBindings, settings::Settings},
+    shapes::{enums::ScreenActionEnum, keybinding::ActionsKeyBindings, settings::Settings},
 };
 use async_trait::async_trait;
 use crokey::{
@@ -48,7 +48,7 @@ pub struct ReportAnIssueScreen {
     footer: NavigationFooter,
     footer_entries: Vec<(String, String)>,
     combiner: Combiner,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 impl Renderable for ReportAnIssueScreen {

--- a/src/screens/scouting_screen.rs
+++ b/src/screens/scouting_screen.rs
@@ -182,7 +182,6 @@ impl<
                 (false, Some(ScreenActionEnum::KeybindingSettings), _, _) => {
                     AppAction::SwitchScreen(Box::new(KeybindingScreen::new(
                         KeyBindingsScreen::<EventTypeEnum>::new(self.settings.clone()),
-                        self.settings.clone(),
                         self.settings_writer.clone(),
                         self.settings_reader.clone(),
                     )))

--- a/src/screens/scouting_screen.rs
+++ b/src/screens/scouting_screen.rs
@@ -21,12 +21,14 @@ use crate::{
 use async_trait::async_trait;
 use chrono::Utc;
 use crokey::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::text::Line;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
     Frame,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -45,7 +47,7 @@ pub struct ScoutingScreen<SSW: SetWriter + Send + Sync> {
     back: bool,
     footer: NavigationFooter,
     set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 #[derive(Debug)]
@@ -57,7 +59,7 @@ pub struct LineupChoiceEntry {
     role: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 enum EventTypeInput {
     Some(EventTypeEnum),
     Partial(char),
@@ -120,7 +122,7 @@ impl<SSW: SetWriter + Send + Sync> Renderable for ScoutingScreen<SSW> {
                 self.render_replacement_choices(f, left_top);
             }
         }
-        let screen_actions = &self.get_sreen_actions();
+        let screen_actions = &self.get_screen_actions();
         let kb = &self.settings.keybindings.clone();
         let footer_entries = get_keybinding_actions(kb, screen_actions);
         let screen_key_bindings = kb.slice(Sba::keys(screen_actions));
@@ -705,14 +707,22 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
             .currently_available_options
             .iter()
             .map(|ev| {
-                Row::new(vec![format!(
-                    "{} ({})",
-                    ev,
-                    ev.friendly_name(current_labels())
-                )])
+                Row::new(vec![
+                    Line::from(ev.to_string()),
+                    Line::from(format!("({})", ev.friendly_name(current_labels()))),
+                    Line::from(se.get(ev).cloned().unwrap_or_default()).right_aligned(),
+                ])
             })
             .collect();
-        let table = Table::new(rows, [Constraint::Percentage(100)]).block(
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(2),
+                Constraint::Percentage(60),
+                Constraint::Min(2),
+            ],
+        )
+        .block(
             Block::default()
                 .borders(Borders::ALL)
                 .title(current_labels().choose_the_event)
@@ -974,7 +984,7 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
         f.render_widget(table, area);
     }
 
-    fn get_sreen_actions(&self) -> Vec<Sba> {
+    fn get_screen_actions(&self) -> Vec<Sba<ScreenActionEnum>> {
         match (self.set.events.len(), &self.state) {
             (0, ScoutingScreenState::Event) => vec![
                 Sba::Simple(ScreenActionEnum::Back),

--- a/src/screens/scouting_screen.rs
+++ b/src/screens/scouting_screen.rs
@@ -1,7 +1,10 @@
 use crate::analytics::global::enqueue_match_for_upload;
+use crate::providers::settings_reader::SettingsReader;
+use crate::providers::settings_writer::SettingsWriter;
+use crate::screens::keybindings_screen::{KeyBindingsScreen, KeybindingScreen};
 use crate::screens::screen::{get_keybinding_actions, Sba};
 use crate::shapes::enums::ScreenActionEnum;
-use crate::shapes::keybinding::ScreenKeyBindings;
+use crate::shapes::keybinding::{ActionsKeyBindings, KeyBindings};
 use crate::shapes::settings::Settings;
 use crate::{
     localization::current_labels,
@@ -21,6 +24,7 @@ use crate::{
 use async_trait::async_trait;
 use chrono::Utc;
 use crokey::crossterm::event::{KeyCode, KeyEvent};
+use crokey::KeyCombinationFormat;
 use ratatui::text::Line;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -28,12 +32,15 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Row, Table},
     Frame,
 };
-use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Debug)]
-pub struct ScoutingScreen<SSW: SetWriter + Send + Sync> {
+pub struct ScoutingScreen<
+    SSW: SetWriter + Send + Sync,
+    SW: SettingsWriter + Send + Sync + 'static,
+    SR: SettingsReader + Send + Sync + 'static,
+> {
     settings: Settings,
     current_match: MatchEntry,
     set: SetEntry,
@@ -47,7 +54,11 @@ pub struct ScoutingScreen<SSW: SetWriter + Send + Sync> {
     back: bool,
     footer: NavigationFooter,
     set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
+    event_screen_key_bindings: ActionsKeyBindings<EventTypeEnum>,
+    event_key_bindings: KeyBindings<EventTypeEnum>,
+    settings_writer: Arc<SW>,
+    settings_reader: Arc<SR>,
 }
 
 #[derive(Debug)]
@@ -62,7 +73,6 @@ pub struct LineupChoiceEntry {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 enum EventTypeInput {
     Some(EventTypeEnum),
-    Partial(char),
     None,
 }
 
@@ -88,7 +98,12 @@ enum ScoutingScreenState {
     Replacement,
 }
 
-impl<SSW: SetWriter + Send + Sync> Renderable for ScoutingScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync,
+        SW: SettingsWriter + Send + Sync,
+        SR: SettingsReader + Send + Sync,
+    > Renderable for ScoutingScreen<SSW, SW, SR>
+{
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         let rows = Layout::default()
             .direction(Direction::Vertical)
@@ -138,7 +153,12 @@ impl<SSW: SetWriter + Send + Sync> Renderable for ScoutingScreen<SSW> {
 }
 
 #[async_trait]
-impl<SSW: SetWriter + Send + Sync> ScreenAsync for ScoutingScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync,
+        SW: SettingsWriter + Send + Sync,
+        SR: SettingsReader + Send + Sync,
+    > ScreenAsync for ScoutingScreen<SSW, SW, SR>
+{
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         use ScoutingScreenState::*;
         if let Some(key_combination) = self.screen_key_bindings.transform(key) {
@@ -159,6 +179,14 @@ impl<SSW: SetWriter + Send + Sync> ScreenAsync for ScoutingScreen<SSW> {
                 (false, Some(ScreenActionEnum::Back), _, _) => {
                     return AppAction::Back(true, self.back_stack_count)
                 }
+                (false, Some(ScreenActionEnum::KeybindingSettings), _, _) => {
+                    AppAction::SwitchScreen(Box::new(KeybindingScreen::new(
+                        KeyBindingsScreen::<EventTypeEnum>::new(self.settings.clone()),
+                        self.settings.clone(),
+                        self.settings_writer.clone(),
+                        self.settings_reader.clone(),
+                    )))
+                }
                 (false, action, _, Event) => self.handle_event_screen(key, action.cloned()).await,
                 (false, action, _, Player) => {
                     return self.handle_player_screen(key, action.cloned()).await
@@ -175,11 +203,26 @@ impl<SSW: SetWriter + Send + Sync> ScreenAsync for ScoutingScreen<SSW> {
         }
     }
 
-    async fn refresh_data(&mut self) {}
+    async fn refresh_data(&mut self) {
+        if let Ok(settings) = &self.settings_reader.read().await {
+            self.settings = settings.to_owned();
+            self.event_key_bindings = settings.scouting_keybindings.clone();
+            self.event_screen_key_bindings = self
+                .event_key_bindings
+                .slice(self.currently_available_options.iter().collect())
+        }
+    }
 }
 
-impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync,
+        SW: SettingsWriter + Send + Sync,
+        SR: SettingsReader + Send + Sync,
+    > ScoutingScreen<SSW, SW, SR>
+{
     pub fn new(
+        settings_reader: Arc<SR>,
+        settings_writer: Arc<SW>,
         settings: Settings,
         current_match: MatchEntry,
         set: SetEntry,
@@ -188,7 +231,10 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
         back_stack_count: Option<u8>,
         set_writer: Arc<SSW>,
     ) -> Self {
+        let event_key_bindings = settings.scouting_keybindings.clone();
         ScoutingScreen {
+            settings_reader,
+            settings_writer,
             settings,
             current_match,
             set,
@@ -202,7 +248,11 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
             back: false,
             footer: NavigationFooter::new(),
             set_writer,
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
+            event_key_bindings: event_key_bindings.to_owned(),
+            event_screen_key_bindings: ActionsKeyBindings::from(
+                event_key_bindings.reverse_map().iter().collect(),
+            ),
         }
     }
 
@@ -347,28 +397,6 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
         }
     }
 
-    fn map_key_to_event(&self, key: KeyCode, last_event: &EventTypeInput) -> EventTypeInput {
-        use EventTypeEnum::*;
-        use EventTypeInput::*;
-        use KeyCode::*;
-        match (key, last_event) {
-            (Char('s'), None) => Some(S),
-            (Char('p'), None) => Some(P),
-            (Char('a'), None) => Some(A),
-            (Char('d'), None) => Some(D),
-            (Char('b'), None) => Some(B),
-            (Char('f'), None) => Some(EventTypeEnum::F),
-            (Char('r'), None) => Some(R),
-            (Char('o'), None) => Partial('o'),
-            (Char('c'), None) => Partial('c'),
-            (Char('e'), Partial('o')) => Some(OE),
-            (Char('s'), Partial('o')) => Some(OS),
-            (Char('l'), Partial('c')) => Some(CL),
-            (Char('s'), Partial('c')) => Some(CS),
-            _ => None,
-        }
-    }
-
     async fn add_event(&mut self, event: &EventEntry) -> AppAction {
         // append event to the file
         let currently_available_options = self
@@ -435,31 +463,31 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
         action: Option<ScreenActionEnum>,
     ) -> AppAction {
         use EventTypeEnum::*;
-        let last_event = self.map_key_to_event(key.code, &self.current_event);
-        match (action, key.code, last_event) {
+        if let Some(ScreenActionEnum::Undo) = action {
             // undo
-            (Some(ScreenActionEnum::Undo), _, _) => self.undo_last_event().await,
-            (_, _, EventTypeInput::Some(event_type)) => {
-                let is_option_available = self.currently_available_options.contains(&event_type);
-                match (is_option_available, event_type) {
+            return self.undo_last_event().await;
+        }
+        if let Some(key_combination) = self.event_screen_key_bindings.transform(key) {
+            if let Some(evt) = self.event_screen_key_bindings.get(key_combination) {
+                match (self.currently_available_options.contains(evt), evt) {
                     // player is inferred when serving
                     (true, S) => {
                         self.player = self.snapshot.current_lineup.get_serving_player();
                         self.state = ScoutingScreenState::Eval;
-                        self.current_event = last_event;
+                        self.current_event = EventTypeInput::Some(S);
                         AppAction::None
                     }
                     // these events require player selection
                     (true, e) if e.requires_player() => {
-                        self.current_event = last_event;
+                        self.current_event = EventTypeInput::Some(*e);
                         self.state = ScoutingScreenState::Player;
                         AppAction::None
                     }
                     // these events do not require player nor evaluation selection
-                    (true, OE | OS | CL) => {
+                    (true, evt) if *evt == OE || *evt == OS || *evt == CL => {
                         let entry = EventEntry {
                             timestamp: Utc::now(),
-                            event_type,
+                            event_type: *evt,
                             eval: None,
                             player: None,
                             target_player: None,
@@ -471,19 +499,15 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
                         self.current_event = EventTypeInput::None;
                         let template = current_labels().event_is_not_available;
                         self.notify_message
-                            .set_error(template.replace("{}", &event_type.to_string()));
+                            .set_error(template.replace("{}", &evt.to_string()));
                         AppAction::None
                     }
                 }
-            }
-            (_, _, EventTypeInput::Partial(c)) => {
-                self.current_event = EventTypeInput::Partial(c);
+            } else {
                 AppAction::None
             }
-            _ => {
-                self.current_event = EventTypeInput::None;
-                AppAction::None
-            }
+        } else {
+            AppAction::None
         }
     }
 
@@ -703,6 +727,8 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
     }
 
     fn render_available_events(&mut self, f: &mut Frame, area: Rect) {
+        let scf = KeyCombinationFormat::default();
+        let se = self.event_key_bindings.clone();
         let rows: Vec<Row> = self
             .currently_available_options
             .iter()
@@ -710,7 +736,14 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
                 Row::new(vec![
                     Line::from(ev.to_string()),
                     Line::from(format!("({})", ev.friendly_name(current_labels()))),
-                    Line::from(se.get(ev).cloned().unwrap_or_default()).right_aligned(),
+                    Line::from(
+                        se.reverse_map()
+                            .get(ev)
+                            .and_then(|set| set.iter().next())
+                            .map(|kc| scf.to_string(*kc))
+                            .unwrap_or_default(),
+                    )
+                    .right_aligned(),
                 ])
             })
             .collect();
@@ -987,13 +1020,13 @@ impl<SSW: SetWriter + Send + Sync> ScoutingScreen<SSW> {
     fn get_screen_actions(&self) -> Vec<Sba<ScreenActionEnum>> {
         match (self.set.events.len(), &self.state) {
             (0, ScoutingScreenState::Event) => vec![
+                Sba::Simple(ScreenActionEnum::KeybindingSettings),
                 Sba::Simple(ScreenActionEnum::Back),
-                Sba::Simple(ScreenActionEnum::Quit),
             ],
             _ => vec![
                 Sba::Simple(ScreenActionEnum::Undo),
+                Sba::Simple(ScreenActionEnum::KeybindingSettings),
                 Sba::Simple(ScreenActionEnum::Back),
-                Sba::Simple(ScreenActionEnum::Quit),
             ],
         }
     }

--- a/src/screens/screen.rs
+++ b/src/screens/screen.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 use crokey::crossterm::event::KeyEvent;
 use ratatui::{layout::Rect, Frame};
 
-use crate::shapes::{
-    enums::ScreenActionEnum, keybinding::KeyBindings, symbol::KeyCombinationFormatExt,
-};
+use crate::shapes::{enums::WithDesc, keybinding::KeyBindings, symbol::KeyCombinationFormatExt};
 
 pub enum AppAction {
     None,
@@ -23,8 +21,10 @@ pub trait ScreenAsync: Renderable + Send + Sync {
     async fn refresh_data(&mut self);
 }
 
-pub fn get_keybinding_actions(kb: &KeyBindings, actions: &[Sba]) -> Vec<(String, String)> {
-    use crate::shapes::enums::ScreenActionEnum;
+pub fn get_keybinding_actions<T>(kb: &KeyBindings<T>, actions: &[Sba<T>]) -> Vec<(String, String)>
+where
+    T: std::hash::Hash + Eq + Clone + WithDesc<T>,
+{
     use crokey::KeyCombinationFormat;
     let fmt = &KeyCombinationFormat::default();
     actions
@@ -41,9 +41,9 @@ pub fn get_keybinding_actions(kb: &KeyBindings, actions: &[Sba]) -> Vec<(String,
                 }
             }
             Sba::Redacted(ae, description_fn) => {
-                fn map_screen_action(
-                    kb: &KeyBindings,
-                    action: &ScreenActionEnum,
+                fn map_screen_action<T: std::hash::Hash + Eq + Clone + WithDesc<T>>(
+                    kb: &KeyBindings<T>,
+                    action: &T,
                     description_fn: fn(String) -> String,
                     fmt: &KeyCombinationFormat,
                 ) -> Option<(String, String)> {
@@ -65,26 +65,27 @@ pub fn get_keybinding_actions(kb: &KeyBindings, actions: &[Sba]) -> Vec<(String,
 }
 
 #[derive(Clone)]
-pub enum Sba {
-    Simple(ScreenActionEnum),
-    Redacted(ScreenActionEnum, fn(String) -> String),
+pub enum Sba<T> {
+    Simple(T),
+    Redacted(T, fn(String) -> String),
 }
-impl Sba {
-    pub fn key(&self) -> &ScreenActionEnum {
+impl<T> Sba<T> {
+    pub fn key(&self) -> &T {
         match self {
             Sba::Simple(ae) => ae,
             Sba::Redacted(ae, _) => ae,
         }
     }
-    pub fn keys(slice: &[Sba]) -> Vec<&ScreenActionEnum> {
+    pub fn keys(slice: &[Sba<T>]) -> Vec<&T> {
         slice.iter().map(|f| f.key()).collect()
     }
 }
 
 #[test]
 fn test_get_keybinding_actions() {
+    use crate::shapes::enums::ScreenActionEnum;
     // Setup test data
-    let kb = KeyBindings::default();
+    let kb = KeyBindings::<ScreenActionEnum>::default();
     let actions = &[
         Sba::Simple(ScreenActionEnum::Next),
         Sba::Simple(ScreenActionEnum::Previous),

--- a/src/screens/settings_screen.rs
+++ b/src/screens/settings_screen.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     shapes::{
         enums::{LanguageEnum, ScreenActionEnum, WithDesc},
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         settings::{set_settings, Settings},
     },
 };
@@ -39,7 +39,7 @@ pub struct SettingsScreen<SW: SettingsWriter + Send + Sync> {
     settings_writer: Arc<SW>,
     settings: Settings,
     format: KeyCombinationFormat,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 impl<SW: SettingsWriter + Send + Sync> Renderable for SettingsScreen<SW> {
@@ -144,6 +144,7 @@ impl<SW: SettingsWriter + Send + Sync> SettingsScreen<SW> {
                     language,
                     analytics_enabled,
                     keybindings: self.settings.keybindings.clone(),
+                    scouting_keybindings: self.settings.scouting_keybindings.clone(),
                     last_used_dir: self.settings.last_used_dir.clone(),
                 };
                 match self.settings_writer.save(settings).await {

--- a/src/screens/settings_screen.rs
+++ b/src/screens/settings_screen.rs
@@ -12,7 +12,7 @@ use crate::{
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::{LanguageEnum, ScreenActionEnum},
+        enums::{LanguageEnum, ScreenActionEnum, WithDesc},
         keybinding::ScreenKeyBindings,
         settings::{set_settings, Settings},
     },
@@ -39,7 +39,7 @@ pub struct SettingsScreen<SW: SettingsWriter + Send + Sync> {
     settings_writer: Arc<SW>,
     settings: Settings,
     format: KeyCombinationFormat,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 impl<SW: SettingsWriter + Send + Sync> Renderable for SettingsScreen<SW> {

--- a/src/screens/start_set_screen.rs
+++ b/src/screens/start_set_screen.rs
@@ -39,7 +39,7 @@ pub struct StartSetScreen<SSW: SetWriter + Send + Sync> {
     list_state: TableState,
     back_stack_count: Option<u8>,
     set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 #[derive(Debug)]

--- a/src/screens/start_set_screen.rs
+++ b/src/screens/start_set_screen.rs
@@ -1,6 +1,8 @@
 use crate::{
     localization::current_labels,
-    providers::set_writer::SetWriter,
+    providers::{
+        set_writer::SetWriter, settings_reader::SettingsReader, settings_writer::SettingsWriter,
+    },
     screens::{
         components::notify_banner::NotifyBanner,
         scouting_screen::ScoutingScreen,
@@ -8,7 +10,7 @@ use crate::{
     },
     shapes::{
         enums::{RoleEnum, ScreenActionEnum, TeamSideEnum},
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         player::PlayerEntry,
         r#match::MatchEntry,
         settings::Settings,
@@ -26,7 +28,13 @@ use std::{collections::HashSet, sync::Arc};
 use uuid::Uuid;
 
 #[derive(Debug)]
-pub struct StartSetScreen<SSW: SetWriter + Send + Sync> {
+pub struct StartSetScreen<
+    SSW: SetWriter + Send + Sync,
+    SW: SettingsWriter + Send + Sync + 'static,
+    SR: SettingsReader + Send + Sync + 'static,
+> {
+    settings_reader: Arc<SR>,
+    settings_writer: Arc<SW>,
     settings: Settings,
     current_match: MatchEntry,
     set_number: u8,
@@ -39,7 +47,7 @@ pub struct StartSetScreen<SSW: SetWriter + Send + Sync> {
     list_state: TableState,
     back_stack_count: Option<u8>,
     set_writer: Arc<SSW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 #[derive(Debug)]
@@ -49,7 +57,12 @@ pub enum StartSetScreenState {
     SelectLineupPlayers(usize, Option<Uuid>, Option<Uuid>),
 }
 
-impl<SSW: SetWriter + Send + Sync + 'static> Renderable for StartSetScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > Renderable for StartSetScreen<SSW, SW, SR>
+{
     fn render(&mut self, f: &mut Frame, body: Rect, footer_left: Rect, footer_right: Rect) {
         use StartSetScreenState::*;
         let rows = Layout::default()
@@ -81,7 +94,12 @@ impl<SSW: SetWriter + Send + Sync + 'static> Renderable for StartSetScreen<SSW> 
 }
 
 #[async_trait]
-impl<SSW: SetWriter + Send + Sync + 'static> ScreenAsync for StartSetScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > ScreenAsync for StartSetScreen<SSW, SW, SR>
+{
     async fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         use StartSetScreenState::*;
         if let Some(key_combination) = self.screen_key_bindings.transform(key) {
@@ -111,7 +129,12 @@ impl<SSW: SetWriter + Send + Sync + 'static> ScreenAsync for StartSetScreen<SSW>
     async fn refresh_data(&mut self) {}
 }
 
-impl<SSW: SetWriter + Send + Sync + 'static> StartSetScreen<SSW> {
+impl<
+        SSW: SetWriter + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
+    > StartSetScreen<SSW, SW, SR>
+{
     fn handle_serving_team_selection(&mut self, action: Option<ScreenActionEnum>) -> AppAction {
         use TeamSideEnum::*;
         match (action, self.serving_team) {
@@ -253,6 +276,8 @@ impl<SSW: SetWriter + Send + Sync + 'static> StartSetScreen<SSW> {
                     }) {
                     Ok((set_entry, snapshot, available_options)) => {
                         AppAction::SwitchScreen(Box::new(ScoutingScreen::new(
+                            self.settings_reader.clone(),
+                            self.settings_writer.clone(),
                             self.settings.clone(),
                             self.current_match.clone(),
                             set_entry,
@@ -422,6 +447,8 @@ impl<SSW: SetWriter + Send + Sync + 'static> StartSetScreen<SSW> {
     }
 
     pub fn new(
+        settings_reader: Arc<SR>,
+        settings_writer: Arc<SW>,
         settings: Settings,
         current_match: MatchEntry,
         set_number: u8,
@@ -430,6 +457,8 @@ impl<SSW: SetWriter + Send + Sync + 'static> StartSetScreen<SSW> {
         set_writer: Arc<SSW>,
     ) -> Self {
         StartSetScreen {
+            settings_reader,
+            settings_writer,
             settings,
             current_match,
             set_number,
@@ -446,7 +475,7 @@ impl<SSW: SetWriter + Send + Sync + 'static> StartSetScreen<SSW> {
             },
             back_stack_count,
             set_writer,
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
         }
     }
 

--- a/src/screens/team_details_screen.rs
+++ b/src/screens/team_details_screen.rs
@@ -24,7 +24,7 @@ use crate::{
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
     },
     shapes::{
-        enums::ScreenActionEnum, keybinding::ScreenKeyBindings, player::PlayerEntry,
+        enums::ScreenActionEnum, keybinding::ActionsKeyBindings, player::PlayerEntry,
         settings::Settings, team::TeamEntry,
     },
 };
@@ -63,7 +63,7 @@ pub struct TeamDetailsScreen<
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]
@@ -337,7 +337,7 @@ impl<
             settings_reader,
             settings_writer,
             notifier: NotifyDialogue::new(),
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
         }
     }
 

--- a/src/screens/team_details_screen.rs
+++ b/src/screens/team_details_screen.rs
@@ -63,7 +63,7 @@ pub struct TeamDetailsScreen<
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
     settings_writer: Arc<SW>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]
@@ -355,7 +355,7 @@ impl<
         }
     }
 
-    fn get_footer_entries(&self) -> Vec<Sba> {
+    fn get_footer_entries(&self) -> Vec<Sba<ScreenActionEnum>> {
         let base_screen_actions = &mut vec![
             Sba::Simple(ScreenActionEnum::EditTeam),
             Sba::Simple(ScreenActionEnum::NewPlayer),

--- a/src/screens/team_list_screen.rs
+++ b/src/screens/team_list_screen.rs
@@ -56,7 +56,7 @@ pub struct TeamListScreen<
     match_writer: Arc<MW>,
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
-    screen_key_bindings: ScreenKeyBindings,
+    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]
@@ -279,7 +279,7 @@ impl<
         }
     }
 
-    fn screen_actions(&self) -> Vec<Sba> {
+    fn screen_actions(&self) -> Vec<Sba<ScreenActionEnum>> {
         if self.teams.is_empty() {
             vec![
                 Sba::Simple(ScreenActionEnum::New),

--- a/src/screens/team_list_screen.rs
+++ b/src/screens/team_list_screen.rs
@@ -12,14 +12,14 @@ use crate::{
         edit_team_screen::EditTeamScreen,
         file_system_screen::FileSystemScreen,
         import_team_screen::ImportTeamAction,
-        keybindings_screen::KeybindingScreen,
+        keybindings_screen::{KeyBindingsScreen, KeybindingScreen},
         screen::{get_keybinding_actions, AppAction, Renderable, Sba, ScreenAsync},
         settings_screen::SettingsScreen,
         team_details_screen::TeamDetailsScreen,
     },
     shapes::{
         enums::{FriendlyName, ScreenActionEnum},
-        keybinding::ScreenKeyBindings,
+        keybinding::ActionsKeyBindings,
         settings::Settings,
         team::TeamEntry,
     },
@@ -56,7 +56,7 @@ pub struct TeamListScreen<
     match_writer: Arc<MW>,
     set_writer: Arc<SSW>,
     settings_reader: Arc<SR>,
-    screen_key_bindings: ScreenKeyBindings<ScreenActionEnum>,
+    screen_key_bindings: ActionsKeyBindings<ScreenActionEnum>,
 }
 
 #[async_trait]
@@ -167,6 +167,7 @@ impl<
                 }
                 (Some(ScreenActionEnum::KeybindingSettings), _, _) => {
                     AppAction::SwitchScreen(Box::new(KeybindingScreen::new(
+                        KeyBindingsScreen::<ScreenActionEnum>::new(self.settings.clone()),
                         self.settings.clone(),
                         self.settings_writer.clone(),
                         self.settings_reader.clone(),
@@ -261,7 +262,7 @@ impl<
             match_writer,
             set_writer,
             settings_reader,
-            screen_key_bindings: ScreenKeyBindings::empty(),
+            screen_key_bindings: ActionsKeyBindings::empty(),
         }
     }
 

--- a/src/screens/team_list_screen.rs
+++ b/src/screens/team_list_screen.rs
@@ -168,7 +168,6 @@ impl<
                 (Some(ScreenActionEnum::KeybindingSettings), _, _) => {
                     AppAction::SwitchScreen(Box::new(KeybindingScreen::new(
                         KeyBindingsScreen::<ScreenActionEnum>::new(self.settings.clone()),
-                        self.settings.clone(),
                         self.settings_writer.clone(),
                         self.settings_reader.clone(),
                     )))
@@ -227,13 +226,13 @@ impl<
 }
 
 impl<
-        TR: TeamReader + Send + Sync,
-        TW: TeamWriter + Send + Sync,
-        SW: SettingsWriter + Send + Sync,
-        MR: MatchReader + Send + Sync,
-        MW: MatchWriter + Send + Sync,
-        SSW: SetWriter + Send + Sync,
-        SR: SettingsReader + Send + Sync,
+        TR: TeamReader + Send + Sync + 'static,
+        TW: TeamWriter + Send + Sync + 'static,
+        SW: SettingsWriter + Send + Sync + 'static,
+        MR: MatchReader + Send + Sync + 'static,
+        MW: MatchWriter + Send + Sync + 'static,
+        SSW: SetWriter + Send + Sync + 'static,
+        SR: SettingsReader + Send + Sync + 'static,
     > TeamListScreen<TR, TW, SW, MR, MW, SSW, SR>
 {
     pub fn new(

--- a/src/shapes/enums.rs
+++ b/src/shapes/enums.rs
@@ -184,7 +184,29 @@ impl fmt::Display for EventTypeEnum {
     }
 }
 
+impl WithDesc<EventTypeEnum> for EventTypeEnum {
+    fn with_desc(self) -> (EventTypeEnum, String) {
+        let labels = current_labels();
+        let desc = self.friendly_name(labels).to_string();
+        (self, desc)
+    }
+}
+
 impl EventTypeEnum {
+    pub const ALL: [EventTypeEnum; 11] = [
+        EventTypeEnum::S,
+        EventTypeEnum::P,
+        EventTypeEnum::A,
+        EventTypeEnum::D,
+        EventTypeEnum::B,
+        EventTypeEnum::F,
+        EventTypeEnum::OS,
+        EventTypeEnum::OE,
+        EventTypeEnum::R,
+        EventTypeEnum::CL,
+        EventTypeEnum::CS,
+    ];
+
     pub fn requires_evaluation(&self) -> bool {
         use EventTypeEnum::*;
         matches!(self, S | P | A | D | B)

--- a/src/shapes/enums.rs
+++ b/src/shapes/enums.rs
@@ -821,7 +821,9 @@ pub enum ScreenActionEnum {
     Reset,
     Undo,
 }
-
+pub trait WithDesc<T> {
+    fn with_desc(self) -> (T, String);
+}
 impl ScreenActionEnum {
     pub const ALL: [ScreenActionEnum; 29] = [
         ScreenActionEnum::Back,
@@ -854,8 +856,10 @@ impl ScreenActionEnum {
         ScreenActionEnum::Reset,
         ScreenActionEnum::Undo,
     ];
+}
 
-    pub fn with_desc(self) -> (ScreenActionEnum, String) {
+impl WithDesc<ScreenActionEnum> for ScreenActionEnum {
+    fn with_desc(self) -> (ScreenActionEnum, String) {
         use ScreenActionEnum::*;
         match self {
             Back => (Back, current_labels().back.to_string()),
@@ -896,6 +900,7 @@ impl ScreenActionEnum {
         }
     }
 }
+
 impl fmt::Display for ScreenActionEnum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ScreenActionEnum::*;

--- a/src/shapes/keybinding.rs
+++ b/src/shapes/keybinding.rs
@@ -19,12 +19,12 @@ where
 
 /// A mapping from key combinations to actions for a specific screen.
 #[derive(Debug)]
-pub struct ScreenKeyBindings<T> {
+pub struct ActionsKeyBindings<T> {
     map: HashMap<KeyCombination, T>,
     combiner: Combiner,
 }
 
-impl<'a, T> IntoIterator for &'a ScreenKeyBindings<T> {
+impl<'a, T> IntoIterator for &'a ActionsKeyBindings<T> {
     type Item = (&'a KeyCombination, &'a T);
     type IntoIter = hash_map::Iter<'a, KeyCombination, T>;
     fn into_iter(self) -> Self::IntoIter {
@@ -32,7 +32,7 @@ impl<'a, T> IntoIterator for &'a ScreenKeyBindings<T> {
     }
 }
 
-impl<T> ScreenKeyBindings<T> {
+impl<T> ActionsKeyBindings<T> {
     pub fn empty() -> Self {
         Self {
             combiner: Combiner::default(),
@@ -66,7 +66,7 @@ impl<T> ScreenKeyBindings<T> {
     }
 }
 
-impl<T> Clone for ScreenKeyBindings<T>
+impl<T> Clone for ActionsKeyBindings<T>
 where
     T: Clone,
 {
@@ -135,11 +135,11 @@ where
         self.default_bindings.clone()
     }
 
-    pub fn slice(&self, actions: Vec<&T>) -> ScreenKeyBindings<T>
+    pub fn slice(&self, actions: Vec<&T>) -> ActionsKeyBindings<T>
     where
         T: Clone + std::hash::Hash + Eq,
     {
-        ScreenKeyBindings::from(
+        ActionsKeyBindings::from(
             actions
                 .iter()
                 .filter_map(|a| self.default_bindings.get(a).map(|cks| (*a, cks)))
@@ -185,12 +185,29 @@ impl Default for KeyBindings<ScreenActionEnum> {
         bindings.set(ScreenActionEnum::ReportAnIssue, key!(i));
         bindings.set(ScreenActionEnum::Select, key!(enter));
         bindings.set(ScreenActionEnum::Reset, key!(r));
+        bindings.set(ScreenActionEnum::Undo, key!(u));
         bindings
     }
 }
-
-
-
+impl Default for KeyBindings<EventTypeEnum> {
+    fn default() -> Self {
+        let mut bindings = Self {
+            default_bindings: HashMap::new(),
+        };
+        bindings.set(EventTypeEnum::S, key!(s));
+        bindings.set(EventTypeEnum::P, key!(p));
+        bindings.set(EventTypeEnum::A, key!(a));
+        bindings.set(EventTypeEnum::D, key!(d));
+        bindings.set(EventTypeEnum::B, key!(b));
+        bindings.set(EventTypeEnum::F, key!(f));
+        bindings.set(EventTypeEnum::R, key!(r));
+        bindings.set(EventTypeEnum::OE, key!(shift - e));
+        bindings.set(EventTypeEnum::OS, key!(shift - s));
+        bindings.set(EventTypeEnum::CL, key!(shift - l));
+        bindings.set(EventTypeEnum::CS, key!(shift - c));
+        bindings
+    }
+}
 #[test]
 fn test_deserialize_keybindings() {
     #[derive(Deserialize)]

--- a/src/shapes/keybinding.rs
+++ b/src/shapes/keybinding.rs
@@ -1,5 +1,5 @@
 use {
-    crate::shapes::enums::ScreenActionEnum,
+    crate::shapes::enums::{EventTypeEnum, ScreenActionEnum, WithDesc},
     crokey::{crossterm::event::KeyEvent, *},
     serde::{Deserialize, Serialize},
     std::collections::{hash_map, HashMap, HashSet},
@@ -9,27 +9,30 @@ use {
 ///
 /// Several key combinations can go to the same action.
 #[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct KeyBindings {
+pub struct KeyBindings<T>
+where
+    T: std::hash::Hash + Eq,
+{
     #[serde(flatten)]
-    default_bindings: HashMap<ScreenActionEnum, HashSet<KeyCombination>>,
+    default_bindings: HashMap<T, HashSet<KeyCombination>>,
 }
 
 /// A mapping from key combinations to actions for a specific screen.
 #[derive(Debug)]
-pub struct ScreenKeyBindings {
-    map: HashMap<KeyCombination, ScreenActionEnum>,
+pub struct ScreenKeyBindings<T> {
+    map: HashMap<KeyCombination, T>,
     combiner: Combiner,
 }
 
-impl<'a> IntoIterator for &'a ScreenKeyBindings {
-    type Item = (&'a KeyCombination, &'a ScreenActionEnum);
-    type IntoIter = hash_map::Iter<'a, KeyCombination, ScreenActionEnum>;
+impl<'a, T> IntoIterator for &'a ScreenKeyBindings<T> {
+    type Item = (&'a KeyCombination, &'a T);
+    type IntoIter = hash_map::Iter<'a, KeyCombination, T>;
     fn into_iter(self) -> Self::IntoIter {
         self.map.iter()
     }
 }
 
-impl ScreenKeyBindings {
+impl<T> ScreenKeyBindings<T> {
     pub fn empty() -> Self {
         Self {
             combiner: Combiner::default(),
@@ -37,7 +40,10 @@ impl ScreenKeyBindings {
         }
     }
 
-    pub fn from(slice: Vec<(&ScreenActionEnum, &HashSet<KeyCombination>)>) -> Self {
+    pub fn from(slice: Vec<(&T, &HashSet<KeyCombination>)>) -> Self
+    where
+        T: Clone + std::hash::Hash + Eq,
+    {
         let mut skb = Self::empty();
         for (action, cks) in slice {
             for ck in cks {
@@ -51,16 +57,19 @@ impl ScreenKeyBindings {
         self.combiner.transform(key)
     }
 
-    fn set<A: Into<ScreenActionEnum>>(&mut self, action: A, ck: KeyCombination) {
+    fn set<A: Into<T>>(&mut self, action: A, ck: KeyCombination) {
         let action_enum = action.into();
         self.map.entry(ck).or_insert(action_enum);
     }
-    pub fn get(&self, key: KeyCombination) -> Option<&ScreenActionEnum> {
+    pub fn get(&self, key: KeyCombination) -> Option<&T> {
         self.map.get(&key)
     }
 }
 
-impl Clone for ScreenKeyBindings {
+impl<T> Clone for ScreenKeyBindings<T>
+where
+    T: Clone,
+{
     fn clone(&self) -> Self {
         Self {
             map: self.map.clone(),
@@ -69,7 +78,77 @@ impl Clone for ScreenKeyBindings {
     }
 }
 
-impl Default for KeyBindings {
+impl<T> KeyBindings<T>
+where
+    T: std::hash::Hash + Eq,
+{
+    pub fn set<A: Into<T>>(&mut self, action: A, ck: KeyCombination) -> bool {
+        self.default_bindings
+            .entry(action.into())
+            .or_default()
+            .insert(ck)
+    }
+
+    pub fn remove<A: Into<T>>(&mut self, action: A, ck: KeyCombination) -> bool {
+        if let Some(set) = self.default_bindings.get_mut(&action.into()) {
+            set.remove(&ck)
+        } else {
+            false
+        }
+    }
+
+    /// return the key combination for the action matching the filter, choosing
+    /// the one with the shortest Display representation.
+    pub fn shortest_key_for(&self, action: &T) -> Option<(KeyCombination, String)>
+    where
+        T: Clone + std::hash::Hash + Eq + WithDesc<T>,
+    {
+        let mut shortest: Option<(KeyCombination, String, T)> = None;
+        if let Some(cks) = self.default_bindings.get(action) {
+            for ck in cks {
+                let s = ck.to_string();
+                match &shortest {
+                    Some(previous) if previous.1.len() < s.len() => {}
+                    _ => {
+                        shortest = Some((*ck, s, action.to_owned()));
+                    }
+                }
+            }
+            shortest.map(|o| (o.0, o.2.with_desc().1))
+        } else {
+            None
+        }
+    }
+
+    pub fn keybindings_for(&self, action: &T) -> HashSet<KeyCombination> {
+        self.default_bindings
+            .get(action)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// build and return a map from actions to all the possible shortcuts
+    pub fn reverse_map(&self) -> HashMap<T, HashSet<KeyCombination>>
+    where
+        T: Clone + std::hash::Hash + Eq,
+    {
+        self.default_bindings.clone()
+    }
+
+    pub fn slice(&self, actions: Vec<&T>) -> ScreenKeyBindings<T>
+    where
+        T: Clone + std::hash::Hash + Eq,
+    {
+        ScreenKeyBindings::from(
+            actions
+                .iter()
+                .filter_map(|a| self.default_bindings.get(a).map(|cks| (*a, cks)))
+                .collect(),
+        )
+    }
+}
+
+impl Default for KeyBindings<ScreenActionEnum> {
     fn default() -> Self {
         let mut bindings = Self {
             default_bindings: HashMap::new(),
@@ -110,69 +189,13 @@ impl Default for KeyBindings {
     }
 }
 
-impl KeyBindings {
-    pub fn set<A: Into<ScreenActionEnum>>(&mut self, action: A, ck: KeyCombination) -> bool {
-        self.default_bindings
-            .entry(action.into())
-            .or_default()
-            .insert(ck)
-    }
 
-    pub fn remove<A: Into<ScreenActionEnum>>(&mut self, action: A, ck: KeyCombination) -> bool {
-        if let Some(set) = self.default_bindings.get_mut(&action.into()) {
-            set.remove(&ck)
-        } else {
-            false
-        }
-    }
-
-    /// return the key combination for the action matching the filter, choosing
-    /// the one with the shortest Display representation.
-    pub fn shortest_key_for(&self, action: &ScreenActionEnum) -> Option<(KeyCombination, String)> {
-        let mut shortest: Option<(KeyCombination, String, ScreenActionEnum)> = None;
-        if let Some(cks) = self.default_bindings.get(action) {
-            for ck in cks {
-                let s = ck.to_string();
-                match &shortest {
-                    Some(previous) if previous.1.len() < s.len() => {}
-                    _ => {
-                        shortest = Some((*ck, s, action.to_owned()));
-                    }
-                }
-            }
-            shortest.map(|o| (o.0, o.2.with_desc().1))
-        } else {
-            None
-        }
-    }
-
-    pub fn keybindings_for(&self, action: &ScreenActionEnum) -> HashSet<KeyCombination> {
-        self.default_bindings
-            .get(action)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    /// build and return a map from actions to all the possible shortcuts
-    pub fn reverse_map(&self) -> HashMap<ScreenActionEnum, HashSet<KeyCombination>> {
-        self.default_bindings.clone()
-    }
-
-    pub fn slice(&self, actions: Vec<&ScreenActionEnum>) -> ScreenKeyBindings {
-        ScreenKeyBindings::from(
-            actions
-                .iter()
-                .filter_map(|a| self.default_bindings.get(a).map(|cks| (*a, cks)))
-                .collect(),
-        )
-    }
-}
 
 #[test]
 fn test_deserialize_keybindings() {
     #[derive(Deserialize)]
     struct Config {
-        keybindings: KeyBindings,
+        keybindings: KeyBindings<ScreenActionEnum>,
     }
     let json = r#"
     {

--- a/src/shapes/settings.rs
+++ b/src/shapes/settings.rs
@@ -1,6 +1,9 @@
 use crate::{
     constants::DEFAULT_LANGUAGE,
-    shapes::{enums::LanguageEnum, keybinding::KeyBindings},
+    shapes::{
+        enums::{LanguageEnum, ScreenActionEnum},
+        keybinding::KeyBindings,
+    },
 };
 use dirs::home_dir;
 use once_cell::sync::OnceCell;
@@ -10,7 +13,7 @@ use std::{path::PathBuf, str::FromStr, sync::RwLock};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub language: LanguageEnum,
-    pub keybindings: KeyBindings,
+    pub keybindings: KeyBindings<ScreenActionEnum>,
     #[serde(default = "default_analytics_enabled")]
     pub analytics_enabled: bool,
     #[serde(default = "default_last_used_dir")]

--- a/src/shapes/settings.rs
+++ b/src/shapes/settings.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::DEFAULT_LANGUAGE,
     shapes::{
-        enums::{LanguageEnum, ScreenActionEnum},
+        enums::{EventTypeEnum, LanguageEnum, ScreenActionEnum},
         keybinding::KeyBindings,
     },
 };
@@ -14,6 +14,7 @@ use std::{path::PathBuf, str::FromStr, sync::RwLock};
 pub struct Settings {
     pub language: LanguageEnum,
     pub keybindings: KeyBindings<ScreenActionEnum>,
+    pub scouting_keybindings: KeyBindings<EventTypeEnum>,
     #[serde(default = "default_analytics_enabled")]
     pub analytics_enabled: bool,
     #[serde(default = "default_last_used_dir")]
@@ -33,6 +34,7 @@ impl Default for Settings {
         Self {
             language: LanguageEnum::from_str(DEFAULT_LANGUAGE).unwrap_or(LanguageEnum::En),
             keybindings: KeyBindings::default(),
+            scouting_keybindings: KeyBindings::default(),
             analytics_enabled: true,
             last_used_dir: None,
         }


### PR DESCRIPTION
closes #38 
 
This pull request refactors keybinding and screen action handling across several screens to improve type safety, extensibility, and maintainability. The main changes involve replacing the `ScreenKeyBindings` type with a new generic `ActionsKeyBindings` type, updating screen structs and implementations to support generic keybinding actions, and enhancing the keybinding management screens to work with arbitrary action types.

### Keybinding System Refactor

* Replaced `ScreenKeyBindings` with a generic `ActionsKeyBindings<T>` type throughout the codebase, allowing screens to handle keybindings for any action type, not just `ScreenActionEnum`. This change affects screen structs, constructors, and keybinding logic. [[1]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL15-R19) [[2]](diffhunk://#diff-2361d90bd1121b85b460ca3c4d9a7cbe4bddbfb6535810ec8166a2a8a800fdd4L15-R15) [[3]](diffhunk://#diff-c00f707e4c583a47657e78a8b77d38653556cc490b97989a787bd9235075e26cL15-R15) [[4]](diffhunk://#diff-7da2680e80d8dfd290380e879c461e5b23984ffcf6ecb65c5c6c212b763af005L9-R9) [[5]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL13-R14) [[6]](diffhunk://#diff-3fe658dc55295d71b7f6eabf9ca41eeb728152dbb90eb9e4e960503d6c7c83c3L8-R13)
* Updated all screen structs (e.g., `AddMatchScreen`, `EditPlayerScreen`, `EditTeamScreen`, `FileSystemScreen`) to use `ActionsKeyBindings<ScreenActionEnum>` instead of `ScreenKeyBindings`. [[1]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL38-R59) [[2]](diffhunk://#diff-2361d90bd1121b85b460ca3c4d9a7cbe4bddbfb6535810ec8166a2a8a800fdd4L46-R46) [[3]](diffhunk://#diff-c00f707e4c583a47657e78a8b77d38653556cc490b97989a787bd9235075e26cL42-R42) [[4]](diffhunk://#diff-7da2680e80d8dfd290380e879c461e5b23984ffcf6ecb65c5c6c212b763af005L52-R52)
* Changed methods and function signatures to work with the new generic keybinding types, including constructors and footer action retrieval. [[1]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL104-R132) [[2]](diffhunk://#diff-7da2680e80d8dfd290380e879c461e5b23984ffcf6ecb65c5c6c212b763af005L180-R180) [[3]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL63-R76) [[4]](diffhunk://#diff-3fe658dc55295d71b7f6eabf9ca41eeb728152dbb90eb9e4e960503d6c7c83c3L142-R160)

### AddMatchScreen and Related Dependency Injection

* Refactored `AddMatchScreen` to take generic `SettingsReader` and `SettingsWriter` types, storing them as fields and passing them to subsequent screens (e.g., `StartSetScreen`), improving dependency injection and testability. [[1]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL5-R8) [[2]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL27-R40) [[3]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecR152-R153) [[4]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecR194-R195)

### Keybinding Management Screens Generalization

* Refactored `AddKeyBindings` and `KeyBindingActionScreen` into generic `AddKeyBindingScreen` and `KeyBindingScreen` types, supporting arbitrary action types with trait bounds (e.g., `WithDesc`, `Hash`, etc.), and allowing screens to manage keybindings for any action type. [[1]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL27-R48) [[2]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL89-R112) [[3]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL102-R124) [[4]](diffhunk://#diff-3fe658dc55295d71b7f6eabf9ca41eeb728152dbb90eb9e4e960503d6c7c83c3R28-R63)
* Updated keybinding add/edit logic to use injected keybinding retriever and updater functions, making keybinding management extensible for different action types. [[1]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfR134-R135) [[2]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL133-R159) [[3]](diffhunk://#diff-3fe658dc55295d71b7f6eabf9ca41eeb728152dbb90eb9e4e960503d6c7c83c3L111-R127)

### Miscellaneous Improvements

* Updated imports and trait bounds across affected files to support new generic types and trait requirements (e.g., `Hash`, `WithDesc`). [[1]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL1-R1) [[2]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL13-R14) [[3]](diffhunk://#diff-3fe658dc55295d71b7f6eabf9ca41eeb728152dbb90eb9e4e960503d6c7c83c3R28-R63)
* Improved consistency and clarity in screen struct definitions and their usage of keybinding-related fields and logic. [[1]](diffhunk://#diff-38c0c982cf59f0cff417c84903c0631a437387d3d1a589c50133667eaf093fecL38-R59) [[2]](diffhunk://#diff-326383aa2b5d9631196c67e82fba060f2ff44e40773273e8a2f76e642528f5cfL27-R48)

These changes modernize the keybinding system and screen action handling, making the codebase more flexible for future enhancements and easier to maintain.